### PR TITLE
list images for a project rather than a category

### DIFF
--- a/lib/procore/resources/images.ex
+++ b/lib/procore/resources/images.ex
@@ -8,16 +8,11 @@ defmodule Procore.Resources.Images do
   alias Procore.ResponseResult
 
   @doc """
-  Lists all images in a image category (album).
+  Lists all images in a Project.
   """
-  @spec list(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (image_category_id :: String.t()) => pos_integer
-        }) :: %ResponseResult{} | %ErrorResult{}
-  def list(
-        client,
-        %{"project_id" => _project_id, "image_category_id" => _image_category_id} = params
-      ) do
+  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
+          %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint("/vapid/images")

--- a/test/resources/images_test.exs
+++ b/test/resources/images_test.exs
@@ -5,7 +5,7 @@ defmodule Procore.Resources.ImagesTest do
 
   test "list/1" do
     client = Procore.client()
-    params = %{"project_id" => 1, "image_category_id" => 1}
+    params = %{"project_id" => 1}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              Images.list(client, params)


### PR DESCRIPTION
Do not require an image category ID to list images.