### PR TITLE
Update all vapid routes to rest/v1.0

### DIFF
--- a/lib/procore/resources/bid_packages.ex
+++ b/lib/procore/resources/bid_packages.ex
@@ -14,7 +14,7 @@ defmodule Procore.Resources.BidPackages do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/bid_packages")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/bid_packages")
     |> Procore.send_request(client)
   end
 
@@ -28,7 +28,7 @@ defmodule Procore.Resources.BidPackages do
   def create(client, %{"project_id" => project_id, "bid_package" => bid_package}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/bid_packages")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/bid_packages")
     |> Request.insert_body(%{"bid_package" => bid_package})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/calendar_events.ex
+++ b/lib/procore/resources/calendar_events.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.CalendarEvents do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/calendar_events")
+    |> Request.insert_endpoint("/rest/v1.0/calendar_events")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/change_event_statuses.ex
+++ b/lib/procore/resources/change_event_statuses.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ChangeEventStatuses do
   def list(client, %{"company_id" => _company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_event/statuses")
+    |> Request.insert_endpoint("/rest/v1.0/change_event/statuses")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/change_events.ex
+++ b/lib/procore/resources/change_events.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ChangeEvents do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_events")
+    |> Request.insert_endpoint("/rest/v1.0/change_events")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -35,7 +35,7 @@ defmodule Procore.Resources.ChangeEvents do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/change_events")
+    |> Request.insert_endpoint("/rest/v1.0/change_events")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"change_event" => change_event})
     |> Procore.send_request(client)

--- a/lib/procore/resources/change_order_statuses.ex
+++ b/lib/procore/resources/change_order_statuses.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ChangeOrderStatuses do
   def list(client, %{"company_id" => _company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_order/statuses")
+    |> Request.insert_endpoint("/rest/v1.0/change_order/statuses")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/commitment_line_item_types.ex
+++ b/lib/procore/resources/commitment_line_item_types.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.CommitmentLineItemTypes do
   def list(client, %{"company_id" => _company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/line_item_types")
+    |> Request.insert_endpoint("/rest/v1.0/line_item_types")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.CommitmentLineItemTypes do
   def sync(client, %{"company_id" => company_id, "line_item_types" => line_item_types}) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/line_item_types/sync")
+    |> Request.insert_endpoint("/rest/v1.0/line_item_types/sync")
     |> Request.insert_body(%{"company_id" => company_id, "updates" => line_item_types})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/companies.ex
+++ b/lib/procore/resources/companies.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.Companies do
   def find(client, %{"id" => id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{id}")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{id}")
     |> Procore.send_request(client)
   end
 
@@ -26,7 +26,7 @@ defmodule Procore.Resources.Companies do
   def list(client) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies")
+    |> Request.insert_endpoint("/rest/v1.0/companies")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/company_checklist_template_sections.ex
+++ b/lib/procore/resources/company_checklist_template_sections.ex
@@ -19,7 +19,7 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections"
+      "/rest/v1.0/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections"
     )
     |> Procore.send_request(client)
   end
@@ -34,7 +34,7 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
   def find(client, %{"company_id" => company_id, "section_id" => section_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/sections/#{section_id}")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/checklist/sections/#{section_id}")
     |> Procore.send_request(client)
   end
 
@@ -54,7 +54,7 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
     %Request{}
     |> Request.insert_request_type(:post)
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections/bulk_create"
+      "/rest/v1.0/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections/bulk_create"
     )
     |> Request.insert_body(%{
       "sections" => sections

--- a/lib/procore/resources/company_checklist_templates.ex
+++ b/lib/procore/resources/company_checklist_templates.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/list_templates")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/checklist/list_templates")
     |> Procore.send_request(client)
   end
 
@@ -30,7 +30,7 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}"
+      "/rest/v1.0/companies/#{company_id}/checklist/list_templates/#{list_template_id}"
     )
     |> Procore.send_request(client)
   end
@@ -50,7 +50,7 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/list_templates")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/checklist/list_templates")
     |> Request.insert_body(%{
       "list_template" => list_template,
       "company_id" => company_id

--- a/lib/procore/resources/company_observation_templates.ex
+++ b/lib/procore/resources/company_observation_templates.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.CompanyObservationTemplates do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/observation_templates")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/observation_templates")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.CompanyObservationTemplates do
   def create(client, %{"company_id" => company_id, "observation_template" => observation_template}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/observation_templates")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/observation_templates")
     |> Request.insert_body(%{"observation_template" => observation_template})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/contributing_behaviors.ex
+++ b/lib/procore/resources/contributing_behaviors.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ContributingBehaviors do
   def list(client, %{"company_id" => company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_behaviors")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/contributing_behaviors")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -34,7 +34,7 @@ defmodule Procore.Resources.ContributingBehaviors do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/contributing_behaviors/#{contributing_behavior_id}"
+      "/rest/v1.0/companies/#{company_id}/contributing_behaviors/#{contributing_behavior_id}"
     )
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
@@ -53,7 +53,7 @@ defmodule Procore.Resources.ContributingBehaviors do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_behaviors")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/contributing_behaviors")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/contributing_conditions.ex
+++ b/lib/procore/resources/contributing_conditions.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ContributingConditions do
   def list(client, %{"company_id" => company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_conditions")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/contributing_conditions")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -34,7 +34,7 @@ defmodule Procore.Resources.ContributingConditions do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/contributing_conditions/#{contributing_condition_id}"
+      "/rest/v1.0/companies/#{company_id}/contributing_conditions/#{contributing_condition_id}"
     )
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
@@ -54,7 +54,7 @@ defmodule Procore.Resources.ContributingConditions do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_conditions")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/contributing_conditions")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/cost_codes.ex
+++ b/lib/procore/resources/cost_codes.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.CostCodes do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/cost_codes")
+    |> Request.insert_endpoint("/rest/v1.0/cost_codes")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/drawing_areas.ex
+++ b/lib/procore/resources/drawing_areas.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.DrawingAreas do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/drawing_areas")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/drawing_areas")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.DrawingAreas do
   def create(client, %{"project_id" => project_id, "name" => name}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/drawing_areas")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/drawing_areas")
     |> Request.insert_body(%{"name" => name})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/hazards.ex
+++ b/lib/procore/resources/hazards.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.Hazards do
   def list(client, %{"company_id" => company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/hazards")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.Hazards do
   def find(client, %{"company_id" => company_id, "hazard_id" => hazard_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards/#{hazard_id}")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/hazards/#{hazard_id}")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -45,7 +45,7 @@ defmodule Procore.Resources.Hazards do
   def create(client, %{"company_id" => company_id, "hazard" => _hazard} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/hazards")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/image_categories.ex
+++ b/lib/procore/resources/image_categories.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ImageCategories do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/image_categories")
+    |> Request.insert_endpoint("/rest/v1.0/image_categories")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.ImageCategories do
   def create(client, %{"project_id" => project_id, "image_category" => image_category}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/image_categories")
+    |> Request.insert_endpoint("/rest/v1.0/image_categories")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"image_category" => image_category, "project_id" => project_id})
     |> Procore.send_request(client)

--- a/lib/procore/resources/images.ex
+++ b/lib/procore/resources/images.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.Images do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/images")
+    |> Request.insert_endpoint("/rest/v1.0/images")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -37,7 +37,7 @@ defmodule Procore.Resources.Images do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/images")
+    |> Request.insert_endpoint("/rest/v1.0/images")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(build_create_body(image_category_id, filename, path_to_file))
     |> Procore.send_request(client)

--- a/lib/procore/resources/inspection_types.ex
+++ b/lib/procore/resources/inspection_types.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.InspectionTypes do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/inspection_types")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/inspection_types")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.InspectionTypes do
   def create(client, %{"company_id" => company_id, "inspection_type" => inspection_type}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/inspection_types")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/inspection_types")
     |> Request.insert_body(%{"inspection_type" => inspection_type})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/locations.ex
+++ b/lib/procore/resources/locations.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.Locations do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/locations")
+    |> Request.insert_endpoint("/rest/v1.0/locations")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.Locations do
   def create(client, %{"project_id" => _project_id, "location" => _location} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/locations")
+    |> Request.insert_endpoint("/rest/v1.0/locations")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/meeting_categories.ex
+++ b/lib/procore/resources/meeting_categories.ex
@@ -25,7 +25,7 @@ defmodule Procore.Resources.MeetingCategories do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meeting_categories")
+    |> Request.insert_endpoint("/rest/v1.0/meeting_categories")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/meeting_topics.ex
+++ b/lib/procore/resources/meeting_topics.ex
@@ -25,7 +25,7 @@ defmodule Procore.Resources.MeetingTopics do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meeting_topics")
+    |> Request.insert_endpoint("/rest/v1.0/meeting_topics")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/meetings.ex
+++ b/lib/procore/resources/meetings.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.Meetings do
   def find(client, %{"meeting_id" => meeting_id, "project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/meetings/#{meeting_id}")
+    |> Request.insert_endpoint("/rest/v1.0/meetings/#{meeting_id}")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.Meetings do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/meetings")
+    |> Request.insert_endpoint("/rest/v1.0/meetings")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -45,7 +45,7 @@ defmodule Procore.Resources.Meetings do
   def create(client, %{"project_id" => _project_id, "meeting" => _meeting} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meetings")
+    |> Request.insert_endpoint("/rest/v1.0/meetings")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/observation_item_response_logs.ex
+++ b/lib/procore/resources/observation_item_response_logs.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.ObservationItemResponseLogs do
   def list(client, %{"project_id" => project_id, "observation_item_id" => item_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items/#{item_id}/response_logs")
+    |> Request.insert_endpoint("/rest/v1.0/observations/items/#{item_id}/response_logs")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -40,7 +40,7 @@ defmodule Procore.Resources.ObservationItemResponseLogs do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/observations/items/#{item_id}/response_logs")
+    |> Request.insert_endpoint("/rest/v1.0/observations/items/#{item_id}/response_logs")
     |> Request.insert_body(%{
       "project_id" => project_id,
       "response_log" => response_log,

--- a/lib/procore/resources/observation_items.ex
+++ b/lib/procore/resources/observation_items.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ObservationItems do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items")
+    |> Request.insert_endpoint("/rest/v1.0/observations/items")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.ObservationItems do
   def find(client, %{"project_id" => project_id, "observation_item_id" => observation_item_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items/#{observation_item_id}")
+    |> Request.insert_endpoint("/rest/v1.0/observations/items/#{observation_item_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -45,7 +45,7 @@ defmodule Procore.Resources.ObservationItems do
   def create(client, %{"project_id" => _project_id, "observation" => _observation_item} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/observations/items")
+    |> Request.insert_endpoint("/rest/v1.0/observations/items")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/observation_types.ex
+++ b/lib/procore/resources/observation_types.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ObservationTypes do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/types")
+    |> Request.insert_endpoint("/rest/v1.0/observations/types")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/offices.ex
+++ b/lib/procore/resources/offices.ex
@@ -21,7 +21,7 @@ defmodule Procore.Resources.Offices do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/offices")
+    |> Request.insert_endpoint("/rest/v1.0/offices")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/permission_templates.ex
+++ b/lib/procore/resources/permission_templates.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.PermissionTemplates do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/permission_templates")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/permission_templates")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/prime_contracts.ex
+++ b/lib/procore/resources/prime_contracts.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.PrimeContracts do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/prime_contract")
+    |> Request.insert_endpoint("/rest/v1.0/prime_contract")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -33,7 +33,7 @@ defmodule Procore.Resources.PrimeContracts do
       ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/prime_contract/#{prime_contract_id}")
+    |> Request.insert_endpoint("/rest/v1.0/prime_contract/#{prime_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -56,7 +56,7 @@ defmodule Procore.Resources.PrimeContracts do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/prime_contract")
+    |> Request.insert_endpoint("/rest/v1.0/prime_contract")
     |> Request.insert_body(%{"project_id" => project_id, "prime_contract" => prime_contract})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/project_checklist_templates.ex
+++ b/lib/procore/resources/project_checklist_templates.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/list_templates")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
   def find(client, %{"project_id" => project_id, "list_template_id" => list_template_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates/#{list_template_id}")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/list_templates/#{list_template_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -48,7 +48,7 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates/create_from_company_template")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/list_templates/create_from_company_template")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/project_checklists.ex
+++ b/lib/procore/resources/project_checklists.ex
@@ -14,7 +14,7 @@ defmodule Procore.Resources.ProjectChecklists do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/lists")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/lists")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -29,7 +29,7 @@ defmodule Procore.Resources.ProjectChecklists do
   def find(client, %{"project_id" => project_id, "checklist_id" => checklist_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/lists/#{checklist_id}")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/lists/#{checklist_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -45,7 +45,7 @@ defmodule Procore.Resources.ProjectChecklists do
   def create(client, %{"project_id" => project_id, "template_id" => template_id, "list" => list}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/checklist/lists")
+    |> Request.insert_endpoint("/rest/v1.0/checklist/lists")
     |> Request.insert_body(%{
       "project_id" => project_id,
       "template_id" => template_id,

--- a/lib/procore/resources/project_configurations.ex
+++ b/lib/procore/resources/project_configurations.ex
@@ -23,7 +23,7 @@ defmodule Procore.Resources.ProjectConfigurations do
   def find(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/project_configuration")
+    |> Request.insert_endpoint("/rest/v1.0/project_configuration")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -44,7 +44,7 @@ defmodule Procore.Resources.ProjectConfigurations do
       }) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/configuration")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/configuration")
     |> Request.insert_body(%{configuration: project_configuration})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/project_tools.ex
+++ b/lib/procore/resources/project_tools.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ProjectTools do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/tools")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/tools")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.ProjectTools do
   def update(client, %{"project_id" => project_id, "project_tools" => project_tools}) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/tools")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/tools")
     |> Request.insert_body(%{tools: project_tools})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/projects.ex
+++ b/lib/procore/resources/projects.ex
@@ -14,7 +14,7 @@ defmodule Procore.Resources.Projects do
   def find(client, %{"company_id" => company_id, "project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -26,7 +26,7 @@ defmodule Procore.Resources.Projects do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects")
+    |> Request.insert_endpoint("/rest/v1.0/projects")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -38,7 +38,7 @@ defmodule Procore.Resources.Projects do
   def create(client, %{"company_id" => company_id, "project" => project}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects")
+    |> Request.insert_endpoint("/rest/v1.0/projects")
     |> Request.insert_body(%{"company_id" => company_id, "project" => project})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/punch_items.ex
+++ b/lib/procore/resources/punch_items.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.PunchItems do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/punch_items")
+    |> Request.insert_endpoint("/rest/v1.0/punch_items")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -30,7 +30,7 @@ defmodule Procore.Resources.PunchItems do
   def create(client, %{"project_id" => _project_id, "punch_item" => _punch_item} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/punch_items")
+    |> Request.insert_endpoint("/rest/v1.0/punch_items")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/purchase_order_contract_line_items.ex
+++ b/lib/procore/resources/purchase_order_contract_line_items.ex
@@ -21,7 +21,7 @@ defmodule Procore.Resources.PurchaseOrderContractLineItems do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
+      "/rest/v1.0/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
     )
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
@@ -43,7 +43,7 @@ defmodule Procore.Resources.PurchaseOrderContractLineItems do
     %Request{}
     |> Request.insert_request_type(:post)
     |> Request.insert_endpoint(
-      "/vapid/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
+      "/rest/v1.0/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
     )
     |> Request.insert_body(%{"project_id" => project_id, "line_item" => line_item})
     |> Procore.send_request(client)

--- a/lib/procore/resources/purchase_order_contracts.ex
+++ b/lib/procore/resources/purchase_order_contracts.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.PurchaseOrderContracts do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts")
+    |> Request.insert_endpoint("/rest/v1.0/purchase_order_contracts")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -33,7 +33,7 @@ defmodule Procore.Resources.PurchaseOrderContracts do
       }) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts/#{purchase_order_contract_id}")
+    |> Request.insert_endpoint("/rest/v1.0/purchase_order_contracts/#{purchase_order_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -51,7 +51,7 @@ defmodule Procore.Resources.PurchaseOrderContracts do
       }) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts/sync")
+    |> Request.insert_endpoint("/rest/v1.0/purchase_order_contracts/sync")
     |> Request.insert_body(%{"project_id" => project_id, "updates" => purchase_order_contracts})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/rfis.ex
+++ b/lib/procore/resources/rfis.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.Rfis do
   def find(client, %{"id" => id, "project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis/#{id}")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/rfis/#{id}")
     |> Procore.send_request(client)
   end
 
@@ -37,7 +37,7 @@ defmodule Procore.Resources.Rfis do
 
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/rfis")
     |> Request.insert_query_params(query)
     |> Procore.send_request(client)
   end
@@ -52,7 +52,7 @@ defmodule Procore.Resources.Rfis do
   def create(client, %{"project_id" => project_id, "rfi" => rfi}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/rfis")
     |> Request.insert_body(build_create_body(rfi))
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/rfis/replies.ex
+++ b/lib/procore/resources/rfis/replies.ex
@@ -18,7 +18,7 @@ defmodule Procore.Resources.Rfis.Replies do
   def create(client, %{"project_id" => project_id, "rfi_id" => rfi_id, "reply" => reply}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis/#{rfi_id}/replies")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/rfis/#{rfi_id}/replies")
     |> Request.insert_body(%{"reply" => reply})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/schedule_resources.ex
+++ b/lib/procore/resources/schedule_resources.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.ScheduleResources do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/resources")
+    |> Request.insert_endpoint("/rest/v1.0/resources")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -28,7 +28,7 @@ defmodule Procore.Resources.ScheduleResources do
   def create(client, %{"project_id" => _project_id, "resource" => _resource} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/resources")
+    |> Request.insert_endpoint("/rest/v1.0/resources")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/schedule_tasks.ex
+++ b/lib/procore/resources/schedule_tasks.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.ScheduleTasks do
   def create(client, %{"project_id" => _project_id, "task" => _task} = params) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/tasks")
+    |> Request.insert_endpoint("/rest/v1.0/tasks")
     |> Request.insert_body(params)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/schedule_todos.ex
+++ b/lib/procore/resources/schedule_todos.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.ScheduleTodos do
   def sync(client, %{"project_id" => project_id, "todos" => todos}) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/todos/sync")
+    |> Request.insert_endpoint("/rest/v1.0/todos/sync")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"udpates" => todos})
     |> Procore.send_request(client)

--- a/lib/procore/resources/specification_sets.ex
+++ b/lib/procore/resources/specification_sets.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.SpecificationSets do
   def find(client, %{"project_id" => project_id, "id" => id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets/#{id}")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/specification_sets/#{id}")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.SpecificationSets do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/specification_sets")
     |> Procore.send_request(client)
   end
 
@@ -43,7 +43,7 @@ defmodule Procore.Resources.SpecificationSets do
   def create(client, %{"project_id" => project_id, "specification_set" => spec_set}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/specification_sets")
     |> Request.insert_body(spec_set)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/specification_uploads.ex
+++ b/lib/procore/resources/specification_uploads.ex
@@ -16,7 +16,7 @@ defmodule Procore.Resources.SpecificationUploads do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_uploads")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/specification_uploads")
     |> Request.insert_body(build_create_body(spec_upload))
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/submittal_packages.ex
+++ b/lib/procore/resources/submittal_packages.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.SubmittalPackages do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittal_packages")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/submittal_packages")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/submittal_status.ex
+++ b/lib/procore/resources/submittal_status.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.SubmittalStatus do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/submittal_statuses")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/submittal_statuses")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/submittals.ex
+++ b/lib/procore/resources/submittals.ex
@@ -17,7 +17,7 @@ defmodule Procore.Resources.Submittals do
   def find(client, %{"id" => id, "project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals/#{id}")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/submittals/#{id}")
     |> Procore.send_request(client)
   end
 
@@ -33,7 +33,7 @@ defmodule Procore.Resources.Submittals do
 
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/submittals")
     |> Request.insert_query_params(query)
     |> Procore.send_request(client)
   end
@@ -48,7 +48,7 @@ defmodule Procore.Resources.Submittals do
   def create(client, %{"project_id" => project_id, "submittal" => submittal}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/submittals")
     |> Request.insert_body(submittal)
     |> Procore.send_request(client)
   end
@@ -63,7 +63,7 @@ defmodule Procore.Resources.Submittals do
     %Request{}
     |> Request.insert_request_type(:get)
     |> Request.insert_endpoint(
-      "/vapid/projects/#{project_id}/submittals/potential_responsible_contractors"
+      "/rest/v1.0/projects/#{project_id}/submittals/potential_responsible_contractors"
     )
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/trades.ex
+++ b/lib/procore/resources/trades.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.Trades do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/trades")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/trades")
     |> Procore.send_request(client)
   end
 
@@ -29,7 +29,7 @@ defmodule Procore.Resources.Trades do
   def create(client, %{"company_id" => company_id, "trade" => trade}) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/trades")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/trades")
     |> Request.insert_body(%{"trade" => trade})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/users.ex
+++ b/lib/procore/resources/users.ex
@@ -22,7 +22,7 @@ defmodule Procore.Resources.Users do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/users/#{user_id}/actions/add")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/users/#{user_id}/actions/add")
     |> Request.insert_body(build_add_user_to_project_body(permission_template_id))
     |> Procore.send_request(client)
   end
@@ -44,7 +44,7 @@ defmodule Procore.Resources.Users do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/users")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/users")
     |> Procore.send_request(client)
   end
 
@@ -56,7 +56,7 @@ defmodule Procore.Resources.Users do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/users")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/users")
     |> Procore.send_request(client)
   end
 
@@ -73,7 +73,7 @@ defmodule Procore.Resources.Users do
       }) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/users/sync")
+    |> Request.insert_endpoint("/rest/v1.0/companies/#{company_id}/users/sync")
     |> Request.insert_body(%{"updates" => users})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/vendors.ex
+++ b/lib/procore/resources/vendors.ex
@@ -21,7 +21,7 @@ defmodule Procore.Resources.Vendors do
   def list(client, %{"company_id" => company_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/vendors")
+    |> Request.insert_endpoint("/rest/v1.0/vendors")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -34,7 +34,7 @@ defmodule Procore.Resources.Vendors do
   def list(client, %{"project_id" => project_id}) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/vendors")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/vendors")
     |> Procore.send_request(client)
   end
 
@@ -51,7 +51,7 @@ defmodule Procore.Resources.Vendors do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/vendors/#{vendor_id}/actions/add")
+    |> Request.insert_endpoint("/rest/v1.0/projects/#{project_id}/vendors/#{vendor_id}/actions/add")
     |> Procore.send_request(client)
   end
 
@@ -68,7 +68,7 @@ defmodule Procore.Resources.Vendors do
       }) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/vendors/sync")
+    |> Request.insert_endpoint("/rest/v1.0/vendors/sync")
     |> Request.insert_body(%{"company_id" => company_id, "updates" => vendors})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/work_order_contract_line_items.ex
+++ b/lib/procore/resources/work_order_contract_line_items.ex
@@ -20,7 +20,7 @@ defmodule Procore.Resources.WorkOrderContractLineItems do
       }) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}/line_items")
+    |> Request.insert_endpoint("/rest/v1.0/work_order_contracts/#{work_order_contract_id}/line_items")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -40,7 +40,7 @@ defmodule Procore.Resources.WorkOrderContractLineItems do
       }) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}/line_items")
+    |> Request.insert_endpoint("/rest/v1.0/work_order_contracts/#{work_order_contract_id}/line_items")
     |> Request.insert_body(%{"project_id" => project_id, "line_item" => line_item})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/work_order_contracts.ex
+++ b/lib/procore/resources/work_order_contracts.ex
@@ -15,7 +15,7 @@ defmodule Procore.Resources.WorkOrderContracts do
   def list(client, %{"project_id" => _project_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts")
+    |> Request.insert_endpoint("/rest/v1.0/work_order_contracts")
     |> Request.insert_query_params(params)
     |> Procore.send_request(client)
   end
@@ -33,7 +33,7 @@ defmodule Procore.Resources.WorkOrderContracts do
       }) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}")
+    |> Request.insert_endpoint("/rest/v1.0/work_order_contracts/#{work_order_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -48,7 +48,7 @@ defmodule Procore.Resources.WorkOrderContracts do
   def sync(client, %{"project_id" => project_id, "work_order_contracts" => work_order_contracts}) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/sync")
+    |> Request.insert_endpoint("/rest/v1.0/work_order_contracts/sync")
     |> Request.insert_body(%{"project_id" => project_id, "updates" => work_order_contracts})
     |> Procore.send_request(client)
   end

--- a/test/mocks/mock_client.ex
+++ b/test/mocks/mock_client.ex
@@ -3,407 +3,407 @@ defmodule HttpClient.MockClient do
 
   @spec get(String.t(), any, any) :: %ResponseResult{}
 
-  def get(_, "/vapid/companies/1", _) do
+  def get(_, "/rest/v1.0/companies/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/companies", _) do
+  def get(_, "/rest/v1.0/companies", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/observation_templates", _) do
+  def get(_, "/rest/v1.0/companies/1/observation_templates", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/submittal_statuses", _) do
+  def get(_, "/rest/v1.0/companies/1/submittal_statuses", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/observations/types", _) do
+  def get(_, "/rest/v1.0/observations/types", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/observations/items", _) do
+  def get(_, "/rest/v1.0/observations/items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/observations/items/1", _) do
+  def get(_, "/rest/v1.0/observations/items/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/observations/items/1/response_logs", _) do
+  def get(_, "/rest/v1.0/observations/items/1/response_logs", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/contributing_behaviors", _) do
+  def get(_, "/rest/v1.0/companies/1/contributing_behaviors", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/contributing_behaviors/1", _) do
+  def get(_, "/rest/v1.0/companies/1/contributing_behaviors/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/contributing_conditions", _) do
+  def get(_, "/rest/v1.0/companies/1/contributing_conditions", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/contributing_conditions/1", _) do
+  def get(_, "/rest/v1.0/companies/1/contributing_conditions/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/hazards", _) do
+  def get(_, "/rest/v1.0/companies/1/hazards", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/hazards/1", _) do
+  def get(_, "/rest/v1.0/companies/1/hazards/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/inspection_types", _) do
+  def get(_, "/rest/v1.0/companies/1/inspection_types", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/submittal_packages", _) do
+  def get(_, "/rest/v1.0/projects/1/submittal_packages", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/change_events", _) do
+  def get(_, "/rest/v1.0/change_events", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/checklist/lists/1", _) do
+  def get(_, "/rest/v1.0/checklist/lists/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/rfis/1", _) do
+  def get(_, "/rest/v1.0/projects/1/rfis/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/rfis", _) do
+  def get(_, "/rest/v1.0/projects/1/rfis", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/submittals/1", _) do
+  def get(_, "/rest/v1.0/projects/1/submittals/1", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/submittals", _) do
+  def get(_, "/rest/v1.0/projects/1/submittals", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/users", _) do
+  def get(_, "/rest/v1.0/companies/1/users", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/users", _) do
+  def get(_, "/rest/v1.0/projects/1/users", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/vendors", _) do
+  def get(_, "/rest/v1.0/projects/1/vendors", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/trades", _) do
+  def get(_, "/rest/v1.0/companies/1/trades", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/checklist/list_templates", _) do
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/checklist/list_templates/1", _) do
+  def get(_, "/rest/v1.0/checklist/list_templates/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects", _) do
+  def get(_, "/rest/v1.0/projects", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1", _) do
+  def get(_, "/rest/v1.0/projects/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/permission_templates", _) do
+  def get(_, "/rest/v1.0/projects/1/permission_templates", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/checklist/list_templates/1", _) do
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/bid_packages", _) do
+  def get(_, "/rest/v1.0/projects/1/bid_packages", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/checklist/list_templates/1/sections", _) do
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates/1/sections", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/companies/1/checklist/sections/1", _) do
+  def get(_, "/rest/v1.0/companies/1/checklist/sections/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/cost_codes", _) do
+  def get(_, "/rest/v1.0/cost_codes", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/change_order/statuses", _) do
+  def get(_, "/rest/v1.0/change_order/statuses", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/change_event/statuses", _) do
+  def get(_, "/rest/v1.0/change_event/statuses", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/work_order_contracts/1/line_items", _) do
+  def get(_, "/rest/v1.0/work_order_contracts/1/line_items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/purchase_order_contracts/1/line_items", _) do
+  def get(_, "/rest/v1.0/purchase_order_contracts/1/line_items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/line_item_types", _) do
+  def get(_, "/rest/v1.0/line_item_types", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/work_order_contracts", _) do
+  def get(_, "/rest/v1.0/work_order_contracts", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/work_order_contracts/1", _) do
+  def get(_, "/rest/v1.0/work_order_contracts/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/purchase_order_contracts", _) do
+  def get(_, "/rest/v1.0/purchase_order_contracts", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/purchase_order_contracts/1", _) do
+  def get(_, "/rest/v1.0/purchase_order_contracts/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/prime_contract", _) do
+  def get(_, "/rest/v1.0/prime_contract", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/prime_contract/1", _) do
+  def get(_, "/rest/v1.0/prime_contract/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/checklist/list_templates", _) do
+  def get(_, "/rest/v1.0/checklist/list_templates", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/checklist/lists", _) do
+  def get(_, "/rest/v1.0/checklist/lists", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/offices", _) do
+  def get(_, "/rest/v1.0/offices", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/project_configuration", _) do
+  def get(_, "/rest/v1.0/project_configuration", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/vendors", _) do
+  def get(_, "/rest/v1.0/vendors", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/locations", _) do
+  def get(_, "/rest/v1.0/locations", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/resources", _) do
+  def get(_, "/rest/v1.0/resources", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/calendar_events", _) do
+  def get(_, "/rest/v1.0/calendar_events", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/meetings/1", _) do
+  def get(_, "/rest/v1.0/meetings/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def get(_, "/vapid/meetings", _) do
+  def get(_, "/rest/v1.0/meetings", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/punch_items", _) do
+  def get(_, "/rest/v1.0/punch_items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/submittals/potential_responsible_contractors", _) do
+  def get(_, "/rest/v1.0/projects/1/submittals/potential_responsible_contractors", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/images", _) do
+  def get(_, "/rest/v1.0/images", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
-  def get(_, "/vapid/projects/1/drawing_areas", _) do
+  def get(_, "/rest/v1.0/projects/1/drawing_areas", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
   @spec post(String.t(), any, any, any) :: %ResponseResult{}
 
-  def post(_, "/vapid/companies/1/contributing_behaviors", _, _) do
+  def post(_, "/rest/v1.0/companies/1/contributing_behaviors", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/contributing_conditions", _, _) do
+  def post(_, "/rest/v1.0/companies/1/contributing_conditions", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/hazards", _, _) do
+  def post(_, "/rest/v1.0/companies/1/hazards", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/observation_templates", _, _) do
+  def post(_, "/rest/v1.0/companies/1/observation_templates", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/observations/items", _, _) do
+  def post(_, "/rest/v1.0/observations/items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/observations/items/1/response_logs", _, _) do
+  def post(_, "/rest/v1.0/observations/items/1/response_logs", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/inspection_types", _, _) do
+  def post(_, "/rest/v1.0/companies/1/inspection_types", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/images", _, _) do
+  def post(_, "/rest/v1.0/images", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/change_events", _, _) do
+  def post(_, "/rest/v1.0/change_events", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/checklist/list_templates/1/sections/bulk_create", _, _) do
+  def post(_, "/rest/v1.0/companies/1/checklist/list_templates/1/sections/bulk_create", _, _) do
     %ResponseResult{status_code: 201, parsed_body: [], reply: :ok}
   end
 
-  def post(_, "/vapid/work_order_contracts/1/line_items", _, _) do
+  def post(_, "/rest/v1.0/work_order_contracts/1/line_items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/purchase_order_contracts/1/line_items", _, _) do
+  def post(_, "/rest/v1.0/purchase_order_contracts/1/line_items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/prime_contract", _, _) do
+  def post(_, "/rest/v1.0/prime_contract", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/checklists/list_templates/create_from_company_template", _, _) do
+  def post(_, "/rest/v1.0/checklists/list_templates/create_from_company_template", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/checklist/list_templates", _, _) do
+  def post(_, "/rest/v1.0/companies/1/checklist/list_templates", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/checklist/lists", _, _) do
+  def post(_, "/rest/v1.0/checklist/lists", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/bid_packages", _, _) do
+  def post(_, "/rest/v1.0/projects/1/bid_packages", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/locations", _, _) do
+  def post(_, "/rest/v1.0/locations", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects", _, _) do
+  def post(_, "/rest/v1.0/projects", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/vendors/1/actions/add", _, _) do
+  def post(_, "/rest/v1.0/projects/1/vendors/1/actions/add", _, _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/users/1/actions/add", _, _) do
+  def post(_, "/rest/v1.0/projects/1/users/1/actions/add", _, _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/meetings", _, _) do
+  def post(_, "/rest/v1.0/meetings", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/meeting_categories", _, _) do
+  def post(_, "/rest/v1.0/meeting_categories", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/meeting_topics", _, _) do
+  def post(_, "/rest/v1.0/meeting_topics", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/punch_items", _, _) do
+  def post(_, "/rest/v1.0/punch_items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/rfis", _, _) do
+  def post(_, "/rest/v1.0/projects/1/rfis", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/rfis/1/replies", _, _) do
+  def post(_, "/rest/v1.0/projects/1/rfis/1/replies", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/resources", _, _) do
+  def post(_, "/rest/v1.0/resources", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/tasks", _, _) do
+  def post(_, "/rest/v1.0/tasks", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/submittals", _, _) do
+  def post(_, "/rest/v1.0/projects/1/submittals", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/projects/1/drawing_areas", _, _) do
+  def post(_, "/rest/v1.0/projects/1/drawing_areas", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/companies/1/trades", _, _) do
+  def post(_, "/rest/v1.0/companies/1/trades", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/checklist/list_templates/create_from_company_template", _, _) do
+  def post(_, "/rest/v1.0/checklist/list_templates/create_from_company_template", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
   @spec patch(String.t(), any, any) :: %ResponseResult{}
 
-  def patch(_, "/vapid/line_item_types/sync", _) do
+  def patch(_, "/rest/v1.0/line_item_types/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def patch(_, "/vapid/work_order_contracts/sync", _) do
+  def patch(_, "/rest/v1.0/work_order_contracts/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def patch(_, "/vapid/purchase_order_contracts/sync", _) do
+  def patch(_, "/rest/v1.0/purchase_order_contracts/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def patch(_, "/vapid/todos/sync", _) do
+  def patch(_, "/rest/v1.0/todos/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def patch(_, "/vapid/companies/1/users/sync", _) do
+  def patch(_, "/rest/v1.0/companies/1/users/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
-  def patch(_, "/vapid/vendors/sync", _) do
+  def patch(_, "/rest/v1.0/vendors/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 end

--- a/test/procore_test.exs
+++ b/test/procore_test.exs
@@ -16,7 +16,7 @@ defmodule ProcoreTest do
     assert_raise ArgumentError, fn ->
       Procore.send_request(%Request{
         request_type: :unset,
-        endpoint: "/vapid/endpoint"
+        endpoint: "/rest/v1.0/endpoint"
       })
     end
   end


### PR DESCRIPTION
https://developers.procore.com/notifications/33

NEW! Rest API is now live - Migrate for added functionality
November 17th 2020, at 8:31 am
Rest is Procore’s new API that replaces the previous API known as Vapid. Rest provides a number of advantages over the original Vapid API, including a new versioning architecture, new resources that provide additional coverage, and a new changelog feature. Please provide your feedback or make a feature request.

Migrate as soon as possible to take advantage of the new functionalities that we are releasing. In January 2021, we will deprecate the Vapid API and decommission it at the end of December 2021 according to our API lifecycle guidelines. During the deprecation stage, we will still support the Vapid endpoints therefore there will be no impact on your apps. However, once decommissioned, these endpoints will no longer be in production nor be supported.

Our Rest API overview provides more information on using versioned resources, making rest API calls and accessing the changelogs.

Please reach out to apisupport@procore.com if you encounter issues or bugs with our API.
