### PR TITLE
Update resources to accept api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config :procore,
   default_version: "v1.0"
 ```
 
-`default_version` sets the rest or vapid API version you would like to be used when not specified in your request.
+`default_version` sets the default API version to use if none is specified in the client request. Should be either "v1.0" (recommended) or "vapid" (legacy).
 
 Add `:procore` to your list of applications if using Elixir 1.3 or lower.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ added everyday!
 Add the following code to your dependencies in your **`mix.exs`** file:
 
 ```elixir
-{:procore, "~> 0.0.1"}
+{:procore, "~> 1.0.0"}
 ```
 
 ## Configuration
@@ -24,8 +24,11 @@ config :procore,
   client_secret: "PROCORE_CLIENT_SECRET"
   host: "PROCORE_HOST_URL"
   oauth_url: "#{PROCORE_HOST_URL}/oauth/token",
-  http_client: Procore.HttpClient
+  http_client: Procore.HttpClient,
+  default_version: "v1.0"
 ```
+
+`default_version` sets the rest or vapid API version you would like to be used when not specified in your request.
 
 Add `:procore` to your list of applications if using Elixir 1.3 or lower.
 
@@ -43,7 +46,7 @@ alias Procore.Resources.Offices
 
 client = Procore.client()
 
-{:ok, response} = client |> Offices.list(%{"company_id" => 1})
+{:ok, response} = client |> Offices.list(%{"company_id" => 1, "api_version" => "v1.1"})
 
 #=> response
 %ResponseResult{

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :procore,
   client_id: "test-client-id",
-  client_secret: "test-client-id"
+  client_secret: "test-client-id",
+  default_version: "v1.0"

--- a/lib/procore.ex
+++ b/lib/procore.ex
@@ -52,13 +52,14 @@ defmodule Procore do
   def send_request(
         %Request{
           request_type: :get,
+          api_version: api_version,
           endpoint: endpoint,
           query_params: query_params
         },
         client
       )
       when byte_size(endpoint) > 0 do
-    http_client().get(client, endpoint, QueryParams.build(query_params))
+    http_client().get(client, "#{api_version}#{endpoint}", QueryParams.build(query_params))
   end
 
   @doc """
@@ -67,6 +68,7 @@ defmodule Procore do
   def send_request(
         %Request{
           request_type: :post,
+          api_version: api_version,
           endpoint: endpoint,
           body: body,
           query_params: query_params
@@ -74,15 +76,18 @@ defmodule Procore do
         client
       )
       when byte_size(endpoint) > 0 do
-    http_client().post(client, endpoint, body, QueryParams.build(query_params))
+    http_client().post(client, "#{api_version}#{endpoint}", body, QueryParams.build(query_params))
   end
 
   @doc """
   Makes a PATCH request.
   """
-  def send_request(%Request{request_type: :patch, endpoint: endpoint, body: body}, client)
+  def send_request(
+        %Request{request_type: :patch, api_version: api_version, endpoint: endpoint, body: body},
+        client
+      )
       when byte_size(endpoint) > 0 do
-    http_client().patch(client, endpoint, body)
+    http_client().patch(client, "#{api_version}#{endpoint}", body)
   end
 
   @doc """

--- a/lib/procore.ex
+++ b/lib/procore.ex
@@ -59,7 +59,11 @@ defmodule Procore do
         client
       )
       when byte_size(endpoint) > 0 do
-    http_client().get(client, "#{api_version}#{endpoint}", QueryParams.build(query_params))
+    http_client().get(
+      client,
+      endpoint_url(api_version, endpoint),
+      QueryParams.build(query_params)
+    )
   end
 
   @doc """
@@ -76,7 +80,12 @@ defmodule Procore do
         client
       )
       when byte_size(endpoint) > 0 do
-    http_client().post(client, "#{api_version}#{endpoint}", body, QueryParams.build(query_params))
+    http_client().post(
+      client,
+      endpoint_url(api_version, endpoint),
+      body,
+      QueryParams.build(query_params)
+    )
   end
 
   @doc """
@@ -87,7 +96,7 @@ defmodule Procore do
         client
       )
       when byte_size(endpoint) > 0 do
-    http_client().patch(client, "#{api_version}#{endpoint}", body)
+    http_client().patch(client, endpoint_url(api_version, endpoint), body)
   end
 
   @doc """
@@ -110,6 +119,10 @@ defmodule Procore do
       :oauth_client,
       Tesla.Middleware.ClientCredentialsOAuth
     )
+  end
+
+  defp endpoint_url(api_version, endpoint) do
+    "#{api_version}#{endpoint}"
   end
 
   def http_client() do

--- a/lib/procore/request.ex
+++ b/lib/procore/request.ex
@@ -7,12 +7,14 @@ defmodule Procore.Request do
 
   @type t :: %__MODULE__{
           body: %{},
+          api_version: String.t(),
           endpoint: String.t(),
           query_params: %{},
           request_type: valid_request_type | :unset
         }
 
   defstruct body: %{},
+            api_version: "",
             endpoint: "",
             query_params: %{},
             request_type: :unset
@@ -23,6 +25,26 @@ defmodule Procore.Request do
   @spec insert_request_type(Request.t(), valid_request_type) :: Request.t()
   def insert_request_type(%__MODULE__{} = request, request_type) do
     %{request | request_type: request_type}
+  end
+
+  # @doc """
+  # Stores API version root.
+  # """
+  @spec insert_api_version(Request.t(), String.t() | nil) :: Request.t()
+  def insert_api_version(%__MODULE__{} = request, version) do
+    api_version =
+      cond do
+        version && version == "vapid" ->
+          "/vapid"
+
+        version != nil ->
+          "/rest/#{version}"
+
+        true ->
+          "/rest/#{Application.get_env(:procore, :default_version)}"
+      end
+
+    %{request | api_version: api_version}
   end
 
   @doc """

--- a/lib/procore/resources/bid_packages.ex
+++ b/lib/procore/resources/bid_packages.ex
@@ -9,12 +9,15 @@ defmodule Procore.Resources.BidPackages do
   @doc """
   List all bid projects in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/bid_packages")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/bid_packages")
     |> Procore.send_request(client)
   end
 
@@ -22,13 +25,15 @@ defmodule Procore.Resources.BidPackages do
   Creates a bid package.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => integer,
-          (bid_package :: String.t()) => map
+          required(project_id :: String.t()) => integer,
+          required(bid_package :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "bid_package" => bid_package}) do
+  def create(client, %{"project_id" => project_id, "bid_package" => bid_package} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/bid_packages")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/bid_packages")
     |> Request.insert_body(%{"bid_package" => bid_package})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/calendar_events.ex
+++ b/lib/procore/resources/calendar_events.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.CalendarEvents do
   @doc """
   Lists all calendar events for a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/calendar_events")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/calendar_events")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/change_event_statuses.ex
+++ b/lib/procore/resources/change_event_statuses.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ChangeEventStatuses do
   @doc """
   Lists all Change Event Statuses with associated records in a project.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
   def list(client, %{"company_id" => _company_id} = params) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_event/statuses")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(params["api_version"])
+    |> Request.insert_endpoint("/change_event/statuses")
+    |> Request.insert_query_params(Map.drop(params, ["version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/change_events.ex
+++ b/lib/procore/resources/change_events.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ChangeEvents do
   @doc """
   Lists all Change Events with associated records in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_events")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/change_events")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,18 +27,23 @@ defmodule Procore.Resources.ChangeEvents do
   Creates a Change Event with its nested, optional, Change Event Line Items.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (attachments :: String.t()) => list,
-          (change_event :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(attachments :: String.t()) => list,
+          required(change_event :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "attachments" => _attachments,
-        "change_event" => change_event
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "attachments" => _attachments,
+          "change_event" => change_event
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/change_events")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/change_events")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"change_event" => change_event})
     |> Procore.send_request(client)

--- a/lib/procore/resources/change_order_statuses.ex
+++ b/lib/procore/resources/change_order_statuses.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ChangeOrderStatuses do
   @doc """
   Lists all Change Order Statuses with associated records in a project.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => _company_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => _company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/change_order/statuses")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/change_order/statuses")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/commitment_line_item_types.ex
+++ b/lib/procore/resources/commitment_line_item_types.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.CommitmentLineItemTypes do
   @doc """
   Lists all Line Item Types in a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => _company_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => _company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/line_item_types")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/line_item_types")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,13 +27,15 @@ defmodule Procore.Resources.CommitmentLineItemTypes do
   Creates or updates a batch of Line Item Types for a company.
   """
   @spec sync(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (line_item_types :: String.t()) => list
+          required(company_id :: String.t()) => pos_integer,
+          required(line_item_types :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{"company_id" => company_id, "line_item_types" => line_item_types}) do
+  def sync(client, %{"company_id" => company_id, "line_item_types" => line_item_types} = options) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/line_item_types/sync")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/line_item_types/sync")
     |> Request.insert_body(%{"company_id" => company_id, "updates" => line_item_types})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/companies.ex
+++ b/lib/procore/resources/companies.ex
@@ -10,23 +10,29 @@ defmodule Procore.Resources.Companies do
   @doc """
   Gets a company.
   """
-  @spec find(Tesla.Client.t(), %{(id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"id" => id}) do
+  @spec find(Tesla.Client.t(), %{
+          required(id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def find(client, %{"id" => id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{id}")
     |> Procore.send_request(client)
   end
 
   @doc """
   List companies.
   """
-  @spec list(Tesla.Client.t()) :: %ResponseResult{} | %ErrorResult{}
-  def list(client) do
+  @spec list(Tesla.Client.t(), %{
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/company_checklist_template_sections.ex
+++ b/lib/procore/resources/company_checklist_template_sections.ex
@@ -12,14 +12,19 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
 
   """
   @spec list(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (list_template_id :: String.t()) => pos_integer
+          required(company_id :: String.t()) => pos_integer,
+          required(list_template_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id, "list_template_id" => list_template_id}) do
+  def list(
+        client,
+        %{"company_id" => company_id, "list_template_id" => list_template_id} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections"
+      "/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections"
     )
     |> Procore.send_request(client)
   end
@@ -28,13 +33,15 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
   Returns Checklist Template.
   """
   @spec find(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (section_id :: String.t()) => pos_integer
+          required(company_id :: String.t()) => pos_integer,
+          required(section_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"company_id" => company_id, "section_id" => section_id}) do
+  def find(client, %{"company_id" => company_id, "section_id" => section_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/sections/#{section_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/checklist/sections/#{section_id}")
     |> Procore.send_request(client)
   end
 
@@ -42,19 +49,24 @@ defmodule Procore.Resources.CompanyChecklistTemplateSections do
   Bulk Creates Company Checklist Sections for a specified Checklist Template.
   """
   @spec bulk_create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (list_template_id :: String.t()) => pos_integer,
-          (sections :: String.t()) => List.t()
+          required(company_id :: String.t()) => pos_integer,
+          required(list_template_id :: String.t()) => pos_integer,
+          required(sections :: String.t()) => List.t(),
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def bulk_create(client, %{
-        "company_id" => company_id,
-        "list_template_id" => list_template_id,
-        "sections" => sections
-      }) do
+  def bulk_create(
+        client,
+        %{
+          "company_id" => company_id,
+          "list_template_id" => list_template_id,
+          "sections" => sections
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections/bulk_create"
+      "/companies/#{company_id}/checklist/list_templates/#{list_template_id}/sections/bulk_create"
     )
     |> Request.insert_body(%{
       "sections" => sections

--- a/lib/procore/resources/company_checklist_templates.ex
+++ b/lib/procore/resources/company_checklist_templates.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
   @doc """
   Lists all Checklist Template for a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/list_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/checklist/list_templates")
     |> Procore.send_request(client)
   end
 
@@ -23,14 +26,19 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
   Returns Checklist Template.
   """
   @spec find(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (list_template_id :: String.t()) => pos_integer
+          required(company_id :: String.t()) => pos_integer,
+          required(list_template_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"company_id" => company_id, "list_template_id" => list_template_id}) do
+  def find(
+        client,
+        %{"company_id" => company_id, "list_template_id" => list_template_id} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/checklist/list_templates/#{list_template_id}"
+      "/companies/#{company_id}/checklist/list_templates/#{list_template_id}"
     )
     |> Procore.send_request(client)
   end
@@ -39,18 +47,23 @@ defmodule Procore.Resources.CompanyChecklistTemplates do
   Creates a company level Checklist Template.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (list_template :: String.t()) => map,
-          (attachments :: String.t()) => List.t()
+          required(company_id :: String.t()) => pos_integer,
+          required(list_template :: String.t()) => map,
+          required(attachments :: String.t()) => List.t(),
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "company_id" => company_id,
-        "list_template" => list_template,
-        "attachments" => _attachments
-      }) do
+  def create(
+        client,
+        %{
+          "company_id" => company_id,
+          "list_template" => list_template,
+          "attachments" => _attachments
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/checklist/list_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/checklist/list_templates")
     |> Request.insert_body(%{
       "list_template" => list_template,
       "company_id" => company_id

--- a/lib/procore/resources/company_observation_templates.ex
+++ b/lib/procore/resources/company_observation_templates.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.CompanyObservationTemplates do
   @doc """
   Lists all observation templates for a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/observation_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/observation_templates")
     |> Procore.send_request(client)
   end
 
@@ -26,10 +29,14 @@ defmodule Procore.Resources.CompanyObservationTemplates do
           (company_id :: String.t()) => pos_integer,
           (observation_template :: String.t()) => map
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"company_id" => company_id, "observation_template" => observation_template}) do
+  def create(
+        client,
+        %{"company_id" => company_id, "observation_template" => observation_template} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/observation_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/observation_templates")
     |> Request.insert_body(%{"observation_template" => observation_template})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/contributing_behaviors.ex
+++ b/lib/procore/resources/contributing_behaviors.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ContributingBehaviors do
   @doc """
   Lists all ContributingBehaviors in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_behaviors")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/contributing_behaviors")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -27,14 +30,18 @@ defmodule Procore.Resources.ContributingBehaviors do
           (company_id :: String.t()) => pos_integer,
           (contributing_behavior_id :: String.t()) => pos_integer
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{
-        "company_id" => company_id,
-        "contributing_behavior_id" => contributing_behavior_id
-      }) do
+  def find(
+        client,
+        %{
+          "company_id" => company_id,
+          "contributing_behavior_id" => contributing_behavior_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/contributing_behaviors/#{contributing_behavior_id}"
+      "/companies/#{company_id}/contributing_behaviors/#{contributing_behavior_id}"
     )
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
@@ -44,17 +51,19 @@ defmodule Procore.Resources.ContributingBehaviors do
   Creates an ContributingBehavior.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (contributing_behavior :: String.t()) => map
+          required(company_id :: String.t()) => pos_integer,
+          required(contributing_behavior :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create(
         client,
-        %{"company_id" => company_id, "contributing_behavior" => _contributing_behavior} = params
+        %{"company_id" => company_id, "contributing_behavior" => _contributing_behavior} = options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_behaviors")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/contributing_behaviors")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/contributing_conditions.ex
+++ b/lib/procore/resources/contributing_conditions.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ContributingConditions do
   @doc """
   Lists all ContributingConditions in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_conditions")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/contributing_conditions")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,17 +27,22 @@ defmodule Procore.Resources.ContributingConditions do
   Gets a single ContributingCondition.
   """
   @spec find(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (contributing_condition_id :: String.t()) => pos_integer
+          required(company_id :: String.t()) => pos_integer,
+          required(contributing_condition_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{
-        "company_id" => company_id,
-        "contributing_condition_id" => contributing_condition_id
-      }) do
+  def find(
+        client,
+        %{
+          "company_id" => company_id,
+          "contributing_condition_id" => contributing_condition_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/companies/#{company_id}/contributing_conditions/#{contributing_condition_id}"
+      "/companies/#{company_id}/contributing_conditions/#{contributing_condition_id}"
     )
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
@@ -44,18 +52,20 @@ defmodule Procore.Resources.ContributingConditions do
   Creates an ContributingCondition.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (contributing_condition :: String.t()) => map
+          required(company_id :: String.t()) => pos_integer,
+          required(contributing_condition :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create(
         client,
         %{"company_id" => company_id, "contributing_condition" => _contributing_condition} =
-          params
+          options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/contributing_conditions")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/contributing_conditions")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/cost_codes.ex
+++ b/lib/procore/resources/cost_codes.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.CostCodes do
   @doc """
   Lists the Cost Codes for a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/cost_codes")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/cost_codes")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/drawing_areas.ex
+++ b/lib/procore/resources/drawing_areas.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.DrawingAreas do
   @doc """
   Lists all drawing areas in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/drawing_areas")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/drawing_areas")
     |> Procore.send_request(client)
   end
 
@@ -23,13 +26,15 @@ defmodule Procore.Resources.DrawingAreas do
   Creates a drawing area.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (name :: String.t()) => String.t()
+          required(project_id :: String.t()) => pos_integer,
+          required(name :: String.t()) => String.t(),
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "name" => name}) do
+  def create(client, %{"project_id" => project_id, "name" => name} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/drawing_areas")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/drawing_areas")
     |> Request.insert_body(%{"name" => name})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/hazards.ex
+++ b/lib/procore/resources/hazards.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.Hazards do
   @doc """
   Lists all Hazards in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/hazards")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,13 +27,15 @@ defmodule Procore.Resources.Hazards do
   Gets a single Hazard.
   """
   @spec find(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (hazard_id :: String.t()) => pos_integer
+          required(company_id :: String.t()) => pos_integer,
+          required(hazard_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"company_id" => company_id, "hazard_id" => hazard_id}) do
+  def find(client, %{"company_id" => company_id, "hazard_id" => hazard_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards/#{hazard_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/hazards/#{hazard_id}")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -39,14 +44,16 @@ defmodule Procore.Resources.Hazards do
   Creates an Hazard.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (hazard :: String.t()) => map
+          required(company_id :: String.t()) => pos_integer,
+          required(hazard :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"company_id" => company_id, "hazard" => _hazard} = params) do
+  def create(client, %{"company_id" => company_id, "hazard" => _hazard} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/hazards")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/hazards")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/image_categories.ex
+++ b/lib/procore/resources/image_categories.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.ImageCategories do
   @doc """
   Lists all image_categories (albums) for a given project_id.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/image_categories")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/image_categories")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -24,13 +27,15 @@ defmodule Procore.Resources.ImageCategories do
   Creates an image category (album).
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (image_category :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(image_category :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "image_category" => image_category}) do
+  def create(client, %{"project_id" => project_id, "image_category" => image_category} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/image_categories")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/image_categories")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"image_category" => image_category, "project_id" => project_id})
     |> Procore.send_request(client)

--- a/lib/procore/resources/images.ex
+++ b/lib/procore/resources/images.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.Images do
   @doc """
   Lists all images in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/images")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/images")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,20 +27,25 @@ defmodule Procore.Resources.Images do
   Creates an image within an image category (album).
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (image_category_id :: String.t()) => pos_integer,
-          (filename :: String.t()) => String.t(),
-          (path_to_file :: String.t()) => String.t()
+          required(project_id :: String.t()) => pos_integer,
+          required(image_category_id :: String.t()) => pos_integer,
+          required(filename :: String.t()) => String.t(),
+          required(path_to_file :: String.t()) => String.t(),
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "image_category_id" => image_category_id,
-        "filename" => filename,
-        "path_to_file" => path_to_file
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "image_category_id" => image_category_id,
+          "filename" => filename,
+          "path_to_file" => path_to_file
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/images")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/images")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(build_create_body(image_category_id, filename, path_to_file))
     |> Procore.send_request(client)

--- a/lib/procore/resources/inspection_types.ex
+++ b/lib/procore/resources/inspection_types.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.InspectionTypes do
   @doc """
   Lists all Inspection Types for a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/inspection_types")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/inspection_types")
     |> Procore.send_request(client)
   end
 
@@ -23,13 +26,18 @@ defmodule Procore.Resources.InspectionTypes do
   Creates an Inspection Type.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (inspection_type :: String.t()) => map
+          required(company_id :: String.t()) => pos_integer,
+          required(inspection_type :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"company_id" => company_id, "inspection_type" => inspection_type}) do
+  def create(
+        client,
+        %{"company_id" => company_id, "inspection_type" => inspection_type} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/inspection_types")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/inspection_types")
     |> Request.insert_body(%{"inspection_type" => inspection_type})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/locations.ex
+++ b/lib/procore/resources/locations.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.Locations do
   @doc """
   Lists all locations in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/locations")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/locations")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -24,14 +27,16 @@ defmodule Procore.Resources.Locations do
   Creates a location.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (location :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(location :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "location" => _location} = params) do
+  def create(client, %{"project_id" => _project_id, "location" => _location} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/locations")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/locations")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/meeting_categories.ex
+++ b/lib/procore/resources/meeting_categories.ex
@@ -11,9 +11,10 @@ defmodule Procore.Resources.MeetingCategories do
   Creates a meeting category.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (meeting_id :: String.t()) => pos_integer,
-          (meeting_category :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(meeting_id :: String.t()) => pos_integer,
+          required(meeting_category :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create(
         client,
@@ -21,12 +22,13 @@ defmodule Procore.Resources.MeetingCategories do
           "project_id" => _project_id,
           "meeting_id" => _meeting_id,
           "meeting_category" => _meeting_category
-        } = params
+        } = options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meeting_categories")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/meeting_categories")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/meeting_topics.ex
+++ b/lib/procore/resources/meeting_topics.ex
@@ -11,9 +11,10 @@ defmodule Procore.Resources.MeetingTopics do
   Creates a meeting topic.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (meeting_id :: String.t()) => pos_integer,
-          (meeting_topic :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(meeting_id :: String.t()) => pos_integer,
+          required(meeting_topic :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create(
         client,
@@ -21,12 +22,13 @@ defmodule Procore.Resources.MeetingTopics do
           "project_id" => _project_id,
           "meeting_id" => _meeting_id,
           "meeting_topic" => _meeting_topic
-        } = params
+        } = options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meeting_topics")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/meeting_topics")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/meetings.ex
+++ b/lib/procore/resources/meetings.ex
@@ -11,27 +11,32 @@ defmodule Procore.Resources.Meetings do
   Gets a meeting with assoication records attendees, attachments, and meeting categories.
   """
   @spec find(Tesla.Client.t(), %{
-          (meeting_id :: String.t()) => pos_integer,
-          (project_id :: String.t()) => pos_integer
+          required(meeting_id :: String.t()) => pos_integer,
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"meeting_id" => meeting_id, "project_id" => _project_id} = params) do
+  def find(client, %{"meeting_id" => meeting_id, "project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/meetings/#{meeting_id}")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/meetings/#{meeting_id}")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
   @doc """
   List all meetings in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/meetings")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/meetings")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -39,14 +44,16 @@ defmodule Procore.Resources.Meetings do
   Creates a meeting.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (meeting :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(meeting :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "meeting" => _meeting} = params) do
+  def create(client, %{"project_id" => _project_id, "meeting" => _meeting} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/meetings")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/meetings")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/observation_item_response_logs.ex
+++ b/lib/procore/resources/observation_item_response_logs.ex
@@ -11,13 +11,15 @@ defmodule Procore.Resources.ObservationItemResponseLogs do
   Lists all ObservationItemResponseLogs in a ObservationItem.
   """
   @spec list(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (observation_item_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(observation_item_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id, "observation_item_id" => item_id}) do
+  def list(client, %{"project_id" => project_id, "observation_item_id" => item_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items/#{item_id}/response_logs")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/items/#{item_id}/response_logs")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -26,21 +28,26 @@ defmodule Procore.Resources.ObservationItemResponseLogs do
   Creates an ObservationItemResponseLog.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (response_log :: String.t()) => map,
-          (status :: String.t()) => String.t(),
-          (attachments :: String.t()) => list
+          required(project_id :: String.t()) => pos_integer,
+          optional(response_log :: String.t()) => map,
+          optional(status :: String.t()) => String.t(),
+          optional(attachments :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "reponse_log" => response_log,
-        "status" => status,
-        "attachments" => attachments,
-        "observation_item_id" => item_id
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "reponse_log" => response_log,
+          "status" => status,
+          "attachments" => attachments,
+          "observation_item_id" => item_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/observations/items/#{item_id}/response_logs")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/items/#{item_id}/response_logs")
     |> Request.insert_body(%{
       "project_id" => project_id,
       "response_log" => response_log,

--- a/lib/procore/resources/observation_items.ex
+++ b/lib/procore/resources/observation_items.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ObservationItems do
   @doc """
   Lists all Observation Items in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/items")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,13 +27,18 @@ defmodule Procore.Resources.ObservationItems do
   Gets a single Observation Item.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (observation_item_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(observation_item_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"project_id" => project_id, "observation_item_id" => observation_item_id}) do
+  def find(
+        client,
+        %{"project_id" => project_id, "observation_item_id" => observation_item_id} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/items/#{observation_item_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/items/#{observation_item_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -39,14 +47,16 @@ defmodule Procore.Resources.ObservationItems do
   Creates an Observation Item.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (observation_item :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(observation_item :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "observation" => _observation_item} = params) do
+  def create(client, %{"project_id" => _project_id, "observation" => _observation_item} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/observations/items")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/items")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/observation_types.ex
+++ b/lib/procore/resources/observation_types.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.ObservationTypes do
   @doc """
   Lists all Observation Types in a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/observations/types")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/observations/types")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/offices.ex
+++ b/lib/procore/resources/offices.ex
@@ -11,17 +11,21 @@ defmodule Procore.Resources.Offices do
   @doc """
   Lists all offices in a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) ::
           %ResponseResult{
             status_code: DefinedTypes.non_error_status_code(),
             parsed_body: ResponseBodyTypes.ListOffices.t(),
             reply: atom
           }
           | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/offices")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/offices")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/permission_templates.ex
+++ b/lib/procore/resources/permission_templates.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.PermissionTemplates do
   @doc """
   List all permission templates in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/permission_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/permission_templates")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/prime_contracts.ex
+++ b/lib/procore/resources/prime_contracts.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.PrimeContracts do
   @doc """
   Lists the Prime Contract for a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/prime_contract")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/prime_contract")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,16 +27,18 @@ defmodule Procore.Resources.PrimeContracts do
   Gets the Prime Contract for the Project.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (prime_contract_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(prime_contract_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def find(
         client,
-        %{"project_id" => project_id, "prime_contract_id" => prime_contract_id} = _params
+        %{"project_id" => project_id, "prime_contract_id" => prime_contract_id} = options
       ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/prime_contract/#{prime_contract_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/prime_contract/#{prime_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -42,9 +47,10 @@ defmodule Procore.Resources.PrimeContracts do
   Creates a the Prime Contract for a Project.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (attachments :: String.t()) => list,
-          (prime_contract :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(attachments :: String.t()) => list,
+          required(prime_contract :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create(
         client,
@@ -52,11 +58,12 @@ defmodule Procore.Resources.PrimeContracts do
           "project_id" => project_id,
           "attachments" => _attachments,
           "prime_contract" => prime_contract
-        } = _params
+        } = options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/prime_contract")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/prime_contract")
     |> Request.insert_body(%{"project_id" => project_id, "prime_contract" => prime_contract})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/project_checklist_templates.ex
+++ b/lib/procore/resources/project_checklist_templates.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
   @doc """
   Lists all Checklist Template for a Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/list_templates")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -24,13 +27,18 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
   Returns a Project Checklist Template.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (list_template_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(list_template_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"project_id" => project_id, "list_template_id" => list_template_id}) do
+  def find(
+        client,
+        %{"project_id" => project_id, "list_template_id" => list_template_id} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates/#{list_template_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/list_templates/#{list_template_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -39,17 +47,19 @@ defmodule Procore.Resources.ProjectChecklistTemplates do
   Creates a Project Checklist Template from a Company Checklist Template.
   """
   @spec create_from_company_template(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (source_template_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(source_template_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
   def create_from_company_template(
         client,
-        %{"project_id" => _project_id, "source_template_id" => _source_template_id} = params
+        %{"project_id" => _project_id, "source_template_id" => _source_template_id} = options
       ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/checklist/list_templates/create_from_company_template")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/list_templates/create_from_company_template")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/project_checklists.ex
+++ b/lib/procore/resources/project_checklists.ex
@@ -9,12 +9,15 @@ defmodule Procore.Resources.ProjectChecklists do
   @doc """
   Lists Inspection Checklists in a specified Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/lists")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/lists")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -23,13 +26,15 @@ defmodule Procore.Resources.ProjectChecklists do
   Returns Project Checklist.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (checklist_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(checklist_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"project_id" => project_id, "checklist_id" => checklist_id}) do
+  def find(client, %{"project_id" => project_id, "checklist_id" => checklist_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/checklist/lists/#{checklist_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/lists/#{checklist_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -38,14 +43,19 @@ defmodule Procore.Resources.ProjectChecklists do
   Creates Project Checklist.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (template_id :: String.t()) => pos_integer,
-          (list :: String.t()) => map()
+          required(project_id :: String.t()) => pos_integer,
+          required(template_id :: String.t()) => pos_integer,
+          required(list :: String.t()) => map(),
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "template_id" => template_id, "list" => list}) do
+  def create(
+        client,
+        %{"project_id" => project_id, "template_id" => template_id, "list" => list} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/checklist/lists")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/checklist/lists")
     |> Request.insert_body(%{
       "project_id" => project_id,
       "template_id" => template_id,

--- a/lib/procore/resources/project_configurations.ex
+++ b/lib/procore/resources/project_configurations.ex
@@ -13,38 +13,49 @@ defmodule Procore.Resources.ProjectConfigurations do
 
   See `Procore.Resources.ProjectConfigurations.ResponseBodyTypes.GetProjectConfiguration.t/0` for response body.
   """
-  @spec find(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
+  @spec find(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) ::
           %ResponseResult{
             status_code: DefinedTypes.non_error_status_code(),
             parsed_body: ResponseBodyTypes.GetProjectConfiguration.t(),
             reply: atom
           }
           | %ErrorResult{}
-  def find(client, %{"project_id" => _project_id} = params) do
+  def find(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/project_configuration")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/project_configuration")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
   @doc """
   Updates a project configuration.
   """
-  @spec update(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
+  @spec update(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) ::
           %ResponseResult{
             status_code: DefinedTypes.non_error_status_code(),
             parsed_body: ResponseBodyTypes.GetProjectConfiguration.t(),
             reply: atom
           }
           | %ErrorResult{}
-  def update(client, %{
-        "project_id" => project_id,
-        "project_configuration" => project_configuration
-      }) do
+  def update(
+        client,
+        %{
+          "project_id" => project_id,
+          "project_configuration" => project_configuration
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/configuration")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/configuration")
     |> Request.insert_body(%{configuration: project_configuration})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/project_tools.ex
+++ b/lib/procore/resources/project_tools.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.ProjectTools do
   @doc """
   Returns all tools available to the provided Project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/tools")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/tools")
     |> Procore.send_request(client)
   end
 
@@ -23,13 +26,15 @@ defmodule Procore.Resources.ProjectTools do
   Updates all tools available to the provided Project.
   """
   @spec update(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (project_tools :: String.t()) => list
+          required(project_id :: String.t()) => pos_integer,
+          required(project_tools :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def update(client, %{"project_id" => project_id, "project_tools" => project_tools}) do
+  def update(client, %{"project_id" => project_id, "project_tools" => project_tools} = options) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/tools")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/tools")
     |> Request.insert_body(%{tools: project_tools})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/projects.ex
+++ b/lib/procore/resources/projects.ex
@@ -11,10 +11,11 @@ defmodule Procore.Resources.Projects do
   Gets a project.
   """
   @spec find(Tesla.Client.t(), map) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"company_id" => company_id, "project_id" => project_id}) do
+  def find(client, %{"company_id" => company_id, "project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -23,10 +24,11 @@ defmodule Procore.Resources.Projects do
   Lists projects.
   """
   @spec list(Tesla.Client.t(), map) :: %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -35,10 +37,11 @@ defmodule Procore.Resources.Projects do
   Creates a project and all of it's required defaults and associations.
   """
   @spec create(Tesla.Client.t(), map) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"company_id" => company_id, "project" => project}) do
+  def create(client, %{"company_id" => company_id, "project" => project} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects")
     |> Request.insert_body(%{"company_id" => company_id, "project" => project})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/punch_items.ex
+++ b/lib/procore/resources/punch_items.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.PunchItems do
   @doc """
   Lists all punch items in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/punch_items")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/punch_items")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,14 +27,16 @@ defmodule Procore.Resources.PunchItems do
   Creates a punch item.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (punch_item :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(punch_item :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "punch_item" => _punch_item} = params) do
+  def create(client, %{"project_id" => _project_id, "punch_item" => _punch_item} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/punch_items")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/punch_items")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/purchase_order_contract_line_items.ex
+++ b/lib/procore/resources/purchase_order_contract_line_items.ex
@@ -11,17 +11,22 @@ defmodule Procore.Resources.PurchaseOrderContractLineItems do
   Lists all Line Items for a specific Purchase Order Contract.
   """
   @spec list(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (purchase_order_contract_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(purchase_order_contract_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def list(client, %{
-        "project_id" => project_id,
-        "purchase_order_contract_id" => purchase_order_contract_id
-      }) do
+  def list(
+        client,
+        %{
+          "project_id" => project_id,
+          "purchase_order_contract_id" => purchase_order_contract_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
+      "/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
     )
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
@@ -31,19 +36,24 @@ defmodule Procore.Resources.PurchaseOrderContractLineItems do
   Creates a Purchase Order Contract Line Item.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (purchase_order_contract_id :: String.t()) => pos_integer,
-          (line_item :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(purchase_order_contract_id :: String.t()) => pos_integer,
+          required(line_item :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "purchase_order_contract_id" => purchase_order_contract_id,
-        "line_item" => line_item
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "purchase_order_contract_id" => purchase_order_contract_id,
+          "line_item" => line_item
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
+      "/purchase_order_contracts/#{purchase_order_contract_id}/line_items"
     )
     |> Request.insert_body(%{"project_id" => project_id, "line_item" => line_item})
     |> Procore.send_request(client)

--- a/lib/procore/resources/purchase_order_contracts.ex
+++ b/lib/procore/resources/purchase_order_contracts.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.PurchaseOrderContracts do
   @doc """
   Lists all Purchase Order Contracts in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/purchase_order_contracts")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,16 +27,21 @@ defmodule Procore.Resources.PurchaseOrderContracts do
   Returns a Purchase Order Contract and associated records.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (purchase_order_contract_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(purchase_order_contract_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{
-        "project_id" => project_id,
-        "purchase_order_contract_id" => purchase_order_contract_id
-      }) do
+  def find(
+        client,
+        %{
+          "project_id" => project_id,
+          "purchase_order_contract_id" => purchase_order_contract_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts/#{purchase_order_contract_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/purchase_order_contracts/#{purchase_order_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -42,16 +50,21 @@ defmodule Procore.Resources.PurchaseOrderContracts do
   Creates or updates a batch of Purchase Order Contracts.
   """
   @spec sync(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (rfi :: String.t()) => list
+          required(project_id :: String.t()) => pos_integer,
+          required(rfi :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{
-        "project_id" => project_id,
-        "purchase_order_contracts" => purchase_order_contracts
-      }) do
+  def sync(
+        client,
+        %{
+          "project_id" => project_id,
+          "purchase_order_contracts" => purchase_order_contracts
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/purchase_order_contracts/sync")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/purchase_order_contracts/sync")
     |> Request.insert_body(%{"project_id" => project_id, "updates" => purchase_order_contracts})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/rfis.ex
+++ b/lib/procore/resources/rfis.ex
@@ -11,33 +11,38 @@ defmodule Procore.Resources.Rfis do
   Find a RFI in a project.
   """
   @spec find(Tesla.Client.t(), %{
-          (id :: String.t()) => pos_integer,
-          (project_id :: String.t()) => pos_integer
+          required(id :: String.t()) => pos_integer,
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"id" => id, "project_id" => project_id}) do
+  def find(client, %{"id" => id, "project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis/#{id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/rfis/#{id}")
     |> Procore.send_request(client)
   end
 
   @doc """
   Lists all RFIs in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
   def list(
         client,
-        %{"project_id" => project_id} = params
+        %{"project_id" => project_id} = options
       ) do
     query = %{
-      "filters" => Map.get(params, "filters", %{}),
-      "serializer_view" => Map.get(params, "serializer_view", "normal")
+      "filters" => Map.get(options, "filters", %{}),
+      "serializer_view" => Map.get(options, "serializer_view", "normal")
     }
 
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/rfis")
     |> Request.insert_query_params(query)
     |> Procore.send_request(client)
   end
@@ -46,13 +51,15 @@ defmodule Procore.Resources.Rfis do
   Creates a RFI.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (rfi :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(rfi :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "rfi" => rfi}) do
+  def create(client, %{"project_id" => project_id, "rfi" => rfi} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/rfis")
     |> Request.insert_body(build_create_body(rfi))
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/rfis/replies.ex
+++ b/lib/procore/resources/rfis/replies.ex
@@ -11,14 +11,19 @@ defmodule Procore.Resources.Rfis.Replies do
   Creates a RFI Reply.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (rfi_id :: String.t()) => pos_integer,
-          (reply :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(rfi_id :: String.t()) => pos_integer,
+          required(reply :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "rfi_id" => rfi_id, "reply" => reply}) do
+  def create(
+        client,
+        %{"project_id" => project_id, "rfi_id" => rfi_id, "reply" => reply} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/rfis/#{rfi_id}/replies")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/rfis/#{rfi_id}/replies")
     |> Request.insert_body(%{"reply" => reply})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/schedule_resources.ex
+++ b/lib/procore/resources/schedule_resources.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.ScheduleResources do
   @doc """
   Lists all schedule resources in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/resources")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/resources")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -23,13 +26,16 @@ defmodule Procore.Resources.ScheduleResources do
   @doc """
   Create a schedule resource.
   """
-  @spec create(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "resource" => _resource} = params) do
+  @spec create(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def create(client, %{"project_id" => _project_id, "resource" => _resource} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/resources")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/resources")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/schedule_tasks.ex
+++ b/lib/procore/resources/schedule_tasks.ex
@@ -11,14 +11,16 @@ defmodule Procore.Resources.ScheduleTasks do
   Create a schedule task.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (task :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(task :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => _project_id, "task" => _task} = params) do
+  def create(client, %{"project_id" => _project_id, "task" => _task} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/tasks")
-    |> Request.insert_body(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/tasks")
+    |> Request.insert_body(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/schedule_todos.ex
+++ b/lib/procore/resources/schedule_todos.ex
@@ -11,13 +11,15 @@ defmodule Procore.Resources.ScheduleTodos do
   Creates or updates a batch of todos.
   """
   @spec sync(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (todos :: String.t()) => list
+          required(project_id :: String.t()) => pos_integer,
+          required(todos :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{"project_id" => project_id, "todos" => todos}) do
+  def sync(client, %{"project_id" => project_id, "todos" => todos} = options) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/todos/sync")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/todos/sync")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Request.insert_body(%{"udpates" => todos})
     |> Procore.send_request(client)

--- a/lib/procore/resources/specification_sets.ex
+++ b/lib/procore/resources/specification_sets.ex
@@ -11,25 +11,30 @@ defmodule Procore.Resources.SpecificationSets do
   Gets a specification set.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"project_id" => project_id, "id" => id}) do
+  def find(client, %{"project_id" => project_id, "id" => id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets/#{id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/specification_sets/#{id}")
     |> Procore.send_request(client)
   end
 
   @doc """
   List all SpecificationSets in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/specification_sets")
     |> Procore.send_request(client)
   end
 
@@ -37,13 +42,15 @@ defmodule Procore.Resources.SpecificationSets do
   Creates a meeting.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (specification_set :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(specification_set :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "specification_set" => spec_set}) do
+  def create(client, %{"project_id" => project_id, "specification_set" => spec_set} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_sets")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/specification_sets")
     |> Request.insert_body(spec_set)
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/specification_uploads.ex
+++ b/lib/procore/resources/specification_uploads.ex
@@ -7,16 +7,21 @@ defmodule Procore.Resources.SpecificationUploads do
   alias Procore.ResponseResult
 
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (specification_upload :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(specification_upload :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "specification_upload" => spec_upload
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "specification_upload" => spec_upload
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/specification_uploads")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/specification_uploads")
     |> Request.insert_body(build_create_body(spec_upload))
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/submittal_packages.ex
+++ b/lib/procore/resources/submittal_packages.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.SubmittalPackages do
   @doc """
   Lists all submittal packages in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittal_packages")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/submittal_packages")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/submittal_status.ex
+++ b/lib/procore/resources/submittal_status.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.SubmittalStatus do
   @doc """
   List all submittal status in a company
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/submittal_statuses")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/submittal_statuses")
     |> Procore.send_request(client)
   end
 end

--- a/lib/procore/resources/submittals.ex
+++ b/lib/procore/resources/submittals.ex
@@ -11,29 +11,34 @@ defmodule Procore.Resources.Submittals do
   Find a submittal in a project.
   """
   @spec find(Tesla.Client.t(), %{
-          (id :: String.t()) => pos_integer,
-          (project_id :: String.t()) => pos_integer
+          required(id :: String.t()) => pos_integer,
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{"id" => id, "project_id" => project_id}) do
+  def find(client, %{"id" => id, "project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals/#{id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/submittals/#{id}")
     |> Procore.send_request(client)
   end
 
   @doc """
   Lists all submittals in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     query = %{
-      "filters" => Map.get(params, "filters", %{})
+      "filters" => Map.get(options, "filters", %{})
     }
 
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/submittals")
     |> Request.insert_query_params(query)
     |> Procore.send_request(client)
   end
@@ -42,13 +47,15 @@ defmodule Procore.Resources.Submittals do
   Creates a submittal.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (submittal :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(submittal :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"project_id" => project_id, "submittal" => submittal}) do
+  def create(client, %{"project_id" => project_id, "submittal" => submittal} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/submittals")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/submittals")
     |> Request.insert_body(submittal)
     |> Procore.send_request(client)
   end
@@ -57,13 +64,15 @@ defmodule Procore.Resources.Submittals do
   Lists all potential responsible contractors.
   """
   @spec list_potential_responsible_contractors(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def list_potential_responsible_contractors(client, %{"project_id" => project_id}) do
+  def list_potential_responsible_contractors(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_endpoint(
-      "/vapid/projects/#{project_id}/submittals/potential_responsible_contractors"
+      "/projects/#{project_id}/submittals/potential_responsible_contractors"
     )
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/trades.ex
+++ b/lib/procore/resources/trades.ex
@@ -10,12 +10,15 @@ defmodule Procore.Resources.Trades do
   @doc """
   Lists all Trades in a company.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/trades")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/trades")
     |> Procore.send_request(client)
   end
 
@@ -23,13 +26,15 @@ defmodule Procore.Resources.Trades do
   Creates a Trade.
   """
   @spec create(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (trade :: String.t()) => map
+          required(company_id :: String.t()) => pos_integer,
+          required(trade :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{"company_id" => company_id, "trade" => trade}) do
+  def create(client, %{"company_id" => company_id, "trade" => trade} = options) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/trades")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/trades")
     |> Request.insert_body(%{"trade" => trade})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/users.ex
+++ b/lib/procore/resources/users.ex
@@ -11,18 +11,23 @@ defmodule Procore.Resources.Users do
   Adds an existing user from a company to a project's directory in that company.
   """
   @spec add_user_to_project(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (user_id :: String.t()) => pos_integer,
-          (permission_template_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(user_id :: String.t()) => pos_integer,
+          required(permission_template_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def add_user_to_project(client, %{
-        "project_id" => project_id,
-        "user_id" => user_id,
-        "permission_template_id" => permission_template_id
-      }) do
+  def add_user_to_project(
+        client,
+        %{
+          "project_id" => project_id,
+          "user_id" => user_id,
+          "permission_template_id" => permission_template_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/users/#{user_id}/actions/add")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/users/#{user_id}/actions/add")
     |> Request.insert_body(build_add_user_to_project_body(permission_template_id))
     |> Procore.send_request(client)
   end
@@ -34,29 +39,36 @@ defmodule Procore.Resources.Users do
   @doc """
   Lists all users in a company directory.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) ::
           %ResponseResult{
             status_code: DefinedTypes.non_error_status_code(),
             parsed_body: ResponseBodyTypes.ListCompanyUsers.t(),
             reply: atom
           }
           | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/users")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/users")
     |> Procore.send_request(client)
   end
 
   @doc """
   Lists all users in a project directory.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/users")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/users")
     |> Procore.send_request(client)
   end
 
@@ -64,16 +76,21 @@ defmodule Procore.Resources.Users do
   Creates or updates a batch of users in a company directory.
   """
   @spec sync(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (users :: String.t()) => list
+          required(company_id :: String.t()) => pos_integer,
+          required(users :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{
-        "company_id" => company_id,
-        "users" => users
-      }) do
+  def sync(
+        client,
+        %{
+          "company_id" => company_id,
+          "users" => users
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/companies/#{company_id}/users/sync")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/companies/#{company_id}/users/sync")
     |> Request.insert_body(%{"updates" => users})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/vendors.ex
+++ b/lib/procore/resources/vendors.ex
@@ -11,17 +11,21 @@ defmodule Procore.Resources.Vendors do
   @doc """
   Lists all vendors in a company directory.
   """
-  @spec list(Tesla.Client.t(), %{(company_id :: String.t()) => pos_integer}) ::
+  @spec list(Tesla.Client.t(), %{
+          required(company_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) ::
           %ResponseResult{
             status_code: DefinedTypes.non_error_status_code(),
             parsed_body: ResponseBodyTypes.ListCompanyVendors.t(),
             reply: atom
           }
           | %ErrorResult{}
-  def list(client, %{"company_id" => company_id}) do
+  def list(client, %{"company_id" => company_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/vendors")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/vendors")
     |> Request.insert_query_params(%{"company_id" => company_id})
     |> Procore.send_request(client)
   end
@@ -29,12 +33,15 @@ defmodule Procore.Resources.Vendors do
   @doc """
   Lists all vendors in a project directory.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => project_id}) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/vendors")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/vendors")
     |> Procore.send_request(client)
   end
 
@@ -42,16 +49,21 @@ defmodule Procore.Resources.Vendors do
   Adds an existing vendor from a company to a project's directory in that company.
   """
   @spec add_vendor_to_project(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (vendor_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(vendor_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def add_vendor_to_project(client, %{
-        "project_id" => project_id,
-        "vendor_id" => vendor_id
-      }) do
+  def add_vendor_to_project(
+        client,
+        %{
+          "project_id" => project_id,
+          "vendor_id" => vendor_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/projects/#{project_id}/vendors/#{vendor_id}/actions/add")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/projects/#{project_id}/vendors/#{vendor_id}/actions/add")
     |> Procore.send_request(client)
   end
 
@@ -59,16 +71,21 @@ defmodule Procore.Resources.Vendors do
   Creates or updates a batch of vendors in a company directory.
   """
   @spec sync(Tesla.Client.t(), %{
-          (company_id :: String.t()) => pos_integer,
-          (vendors :: String.t()) => list
+          required(company_id :: String.t()) => pos_integer,
+          required(vendors :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{
-        "company_id" => company_id,
-        "vendors" => vendors
-      }) do
+  def sync(
+        client,
+        %{
+          "company_id" => company_id,
+          "vendors" => vendors
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/vendors/sync")
+    |> Request.insert_endpoint("/vendors/sync")
+    |> Request.insert_api_version(options["api_version"])
     |> Request.insert_body(%{"company_id" => company_id, "updates" => vendors})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/work_order_contract_line_items.ex
+++ b/lib/procore/resources/work_order_contract_line_items.ex
@@ -11,16 +11,21 @@ defmodule Procore.Resources.WorkOrderContractLineItems do
   Lists all Line Items for a specific Work Order Contract.
   """
   @spec list(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (work_order_contract_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(work_order_contract_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def list(client, %{
-        "project_id" => project_id,
-        "work_order_contract_id" => work_order_contract_id
-      }) do
+  def list(
+        client,
+        %{
+          "project_id" => project_id,
+          "work_order_contract_id" => work_order_contract_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}/line_items")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/work_order_contracts/#{work_order_contract_id}/line_items")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -29,18 +34,23 @@ defmodule Procore.Resources.WorkOrderContractLineItems do
   Creates a Work Order Contract Line Item.
   """
   @spec create(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (work_order_contract_id :: String.t()) => pos_integer,
-          (line_item :: String.t()) => map
+          required(project_id :: String.t()) => pos_integer,
+          required(work_order_contract_id :: String.t()) => pos_integer,
+          required(line_item :: String.t()) => map,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def create(client, %{
-        "project_id" => project_id,
-        "work_order_contract_id" => work_order_contract_id,
-        "line_item" => line_item
-      }) do
+  def create(
+        client,
+        %{
+          "project_id" => project_id,
+          "work_order_contract_id" => work_order_contract_id,
+          "line_item" => line_item
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:post)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}/line_items")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/work_order_contracts/#{work_order_contract_id}/line_items")
     |> Request.insert_body(%{"project_id" => project_id, "line_item" => line_item})
     |> Procore.send_request(client)
   end

--- a/lib/procore/resources/work_order_contracts.ex
+++ b/lib/procore/resources/work_order_contracts.ex
@@ -10,13 +10,16 @@ defmodule Procore.Resources.WorkOrderContracts do
   @doc """
   Lists all Work Order Contracts in a project.
   """
-  @spec list(Tesla.Client.t(), %{(project_id :: String.t()) => pos_integer}) ::
-          %ResponseResult{} | %ErrorResult{}
-  def list(client, %{"project_id" => _project_id} = params) do
+  @spec list(Tesla.Client.t(), %{
+          required(project_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
+        }) :: %ResponseResult{} | %ErrorResult{}
+  def list(client, %{"project_id" => _project_id} = options) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts")
-    |> Request.insert_query_params(params)
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/work_order_contracts")
+    |> Request.insert_query_params(Map.drop(options, ["api_version"]))
     |> Procore.send_request(client)
   end
 
@@ -24,16 +27,21 @@ defmodule Procore.Resources.WorkOrderContracts do
   Returns a Work Order Contract and associated records.
   """
   @spec find(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (work_order_contract_id :: String.t()) => pos_integer
+          required(project_id :: String.t()) => pos_integer,
+          required(work_order_contract_id :: String.t()) => pos_integer,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def find(client, %{
-        "project_id" => project_id,
-        "work_order_contract_id" => work_order_contract_id
-      }) do
+  def find(
+        client,
+        %{
+          "project_id" => project_id,
+          "work_order_contract_id" => work_order_contract_id
+        } = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:get)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/#{work_order_contract_id}")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/work_order_contracts/#{work_order_contract_id}")
     |> Request.insert_query_params(%{"project_id" => project_id})
     |> Procore.send_request(client)
   end
@@ -42,13 +50,18 @@ defmodule Procore.Resources.WorkOrderContracts do
   Creates or updates a batch of Work Order Contracts.
   """
   @spec sync(Tesla.Client.t(), %{
-          (project_id :: String.t()) => pos_integer,
-          (rfi :: String.t()) => list
+          required(project_id :: String.t()) => pos_integer,
+          required(rfi :: String.t()) => list,
+          optional(api_version :: String.t()) => String.t()
         }) :: %ResponseResult{} | %ErrorResult{}
-  def sync(client, %{"project_id" => project_id, "work_order_contracts" => work_order_contracts}) do
+  def sync(
+        client,
+        %{"project_id" => project_id, "work_order_contracts" => work_order_contracts} = options
+      ) do
     %Request{}
     |> Request.insert_request_type(:patch)
-    |> Request.insert_endpoint("/vapid/work_order_contracts/sync")
+    |> Request.insert_api_version(options["api_version"])
+    |> Request.insert_endpoint("/work_order_contracts/sync")
     |> Request.insert_body(%{"project_id" => project_id, "updates" => work_order_contracts})
     |> Procore.send_request(client)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Procore.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       start_permanent: Mix.env() == :prod,
-      version: "0.0.1"
+      version: "1.0.0"
     ]
   end
 

--- a/test/mocks/mock_client.ex
+++ b/test/mocks/mock_client.ex
@@ -7,7 +7,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/companies", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -15,7 +31,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/observation_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/observation_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/submittal_statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/submittal_statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/submittal_statuses", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -23,7 +55,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/observations/types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/observations/types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/observations/items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/observations/items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/observations/items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -31,7 +79,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/observations/items/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/observations/items/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/observations/items/1/response_logs", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/observations/items/1/response_logs", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/observations/items/1/response_logs", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -39,7 +103,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/contributing_behaviors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/contributing_behaviors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/contributing_behaviors/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/contributing_behaviors/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/contributing_behaviors/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -47,7 +127,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/contributing_conditions", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/contributing_conditions", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/contributing_conditions/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/contributing_conditions/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/contributing_conditions/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -55,7 +151,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/hazards", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/hazards", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/hazards/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/hazards/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/hazards/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -63,7 +175,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/inspection_types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/inspection_types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/projects/1/submittal_packages", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/submittal_packages", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/submittal_packages", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -71,7 +199,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/change_events", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/change_events", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/checklist/lists/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/checklist/lists/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/checklist/lists/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -79,7 +223,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/rfis/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/rfis/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/projects/1/rfis", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/rfis", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/rfis", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -87,7 +247,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/submittals/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/submittals/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/projects/1/submittals", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/submittals", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/submittals", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -95,7 +271,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/users", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/users", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/projects/1/users", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/users", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/users", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -103,7 +295,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/vendors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/vendors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/trades", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/trades", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/trades", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -111,7 +319,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/checklist/list_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/checklist/list_templates/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/checklist/list_templates/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/checklist/list_templates/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -119,7 +343,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/projects/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -127,7 +367,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/permission_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/permission_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/checklist/list_templates/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/checklist/list_templates/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -135,7 +391,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/bid_packages", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/bid_packages", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/companies/1/checklist/list_templates/1/sections", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/companies/1/checklist/list_templates/1/sections", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/checklist/list_templates/1/sections", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -143,7 +415,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/companies/1/checklist/sections/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/companies/1/checklist/sections/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/cost_codes", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/cost_codes", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/cost_codes", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -151,7 +439,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/change_order/statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/change_order/statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/change_event/statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/change_event/statuses", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/change_event/statuses", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -159,7 +463,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/work_order_contracts/1/line_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/work_order_contracts/1/line_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/purchase_order_contracts/1/line_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/purchase_order_contracts/1/line_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/purchase_order_contracts/1/line_items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -167,7 +487,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/line_item_types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/line_item_types", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/work_order_contracts", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/work_order_contracts", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/work_order_contracts", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -175,7 +511,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/work_order_contracts/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/work_order_contracts/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/purchase_order_contracts", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/purchase_order_contracts", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/purchase_order_contracts", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -183,7 +535,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/purchase_order_contracts/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/purchase_order_contracts/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/prime_contract", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/prime_contract", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/prime_contract", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -191,7 +559,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/prime_contract/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/prime_contract/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/checklist/list_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/checklist/list_templates", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/checklist/list_templates", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -199,7 +583,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/checklist/lists", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/checklist/lists", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/offices", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/offices", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/offices", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -207,7 +607,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/project_configuration", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/project_configuration", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def get(_, "/vapid/vendors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/vendors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/vendors", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -215,7 +631,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/locations", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/locations", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/resources", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/resources", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/resources", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -223,7 +655,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/calendar_events", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/calendar_events", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/meetings/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/meetings/1", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/meetings/1", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -231,7 +679,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/meetings", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/meetings", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/punch_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/punch_items", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/punch_items", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -239,7 +703,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/submittals/potential_responsible_contractors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/submittals/potential_responsible_contractors", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   def get(_, "/vapid/images", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/images", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/images", _) do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
@@ -247,9 +727,97 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
+  def get(_, "/rest/v1.0/projects/1/drawing_areas", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/drawing_areas", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/vapid/projects/1/specification_sets/2", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/specification_sets/2", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/specification_sets/2", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/vapid/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/vapid/image_categories", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/image_categories", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/image_categories", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/vapid/projects/1/tools", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.0/projects/1/tools", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def get(_, "/rest/v1.1/projects/1/tools", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
   @spec post(String.t(), any, any, any) :: %ResponseResult{}
 
+  def post(_, "/vapid/image_categories", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/image_categories", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/image_categories", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/vapid/projects/1/specification_sets", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/specification_sets", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/specification_sets", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/companies/1/contributing_behaviors", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/companies/1/contributing_behaviors", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/contributing_behaviors", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -257,7 +825,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/companies/1/contributing_conditions", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/contributing_conditions", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/companies/1/hazards", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/companies/1/hazards", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/hazards", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -265,7 +849,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/companies/1/observation_templates", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/observation_templates", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/observations/items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/observations/items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/observations/items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -273,7 +873,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/observations/items/1/response_logs", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/observations/items/1/response_logs", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/companies/1/inspection_types", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/companies/1/inspection_types", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/inspection_types", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -281,7 +897,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/images", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/images", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/change_events", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/change_events", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/change_events", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -289,7 +921,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: [], reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/companies/1/checklist/list_templates/1/sections/bulk_create", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: [], reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/checklist/list_templates/1/sections/bulk_create", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: [], reply: :ok}
+  end
+
   def post(_, "/vapid/work_order_contracts/1/line_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/work_order_contracts/1/line_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/work_order_contracts/1/line_items", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -297,11 +945,35 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/purchase_order_contracts/1/line_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/purchase_order_contracts/1/line_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/prime_contract", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/checklists/list_templates/create_from_company_template", _, _) do
+  def post(_, "/rest/v1.0/prime_contract", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/prime_contract", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/vapid/checklist/list_templates/create_from_company_template", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/checklist/list_templates/create_from_company_template", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/checklist/list_templates/create_from_company_template", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -309,7 +981,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/companies/1/checklist/list_templates", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/checklist/list_templates", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/checklist/lists", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/checklist/lists", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/checklist/lists", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -317,7 +1005,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/projects/1/bid_packages", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/bid_packages", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/locations", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/locations", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/locations", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -325,7 +1029,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/projects", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/projects/1/vendors/1/actions/add", _, _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/vendors/1/actions/add", _, _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/vendors/1/actions/add", _, _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -333,7 +1053,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/projects/1/users/1/actions/add", _, _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/users/1/actions/add", _, _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/meetings", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/meetings", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/meetings", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -341,7 +1077,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/meeting_categories", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/meeting_categories", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/meeting_topics", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/meeting_topics", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/meeting_topics", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -349,7 +1101,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/punch_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/punch_items", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/projects/1/rfis", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/rfis", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/rfis", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -357,7 +1125,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/projects/1/rfis/1/replies", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/rfis/1/replies", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/resources", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/resources", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/resources", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -365,7 +1149,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/tasks", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/tasks", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/projects/1/submittals", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/submittals", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/submittals", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
@@ -373,12 +1173,48 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
+  def post(_, "/rest/v1.0/projects/1/drawing_areas", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/drawing_areas", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
   def post(_, "/vapid/companies/1/trades", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
   end
 
-  def post(_, "/vapid/checklist/list_templates/create_from_company_template", _, _) do
+  def post(_, "/rest/v1.0/companies/1/trades", _, _) do
     %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/companies/1/trades", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/vapid/projects/1/specification_uploads", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/specification_uploads", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/specification_uploads", _, _) do
+    %ResponseResult{status_code: 201, parsed_body: %{}, reply: :ok}
+  end
+
+  def post(_, "/vapid/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def post(_, "/rest/v1.0/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
+  end
+
+  def post(_, "/rest/v1.1/projects/1/specification_sets", _) do
+    %ResponseResult{status_code: 200, parsed_body: [], reply: :ok}
   end
 
   @spec patch(String.t(), any, any) :: %ResponseResult{}
@@ -387,7 +1223,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def patch(_, "/rest/v1.0/line_item_types/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/line_item_types/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def patch(_, "/vapid/work_order_contracts/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.0/work_order_contracts/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/work_order_contracts/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -395,7 +1247,23 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def patch(_, "/rest/v1.0/purchase_order_contracts/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/purchase_order_contracts/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def patch(_, "/vapid/todos/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.0/todos/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/todos/sync", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
@@ -403,7 +1271,35 @@ defmodule HttpClient.MockClient do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 
+  def patch(_, "/rest/v1.0/companies/1/users/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/companies/1/users/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
   def patch(_, "/vapid/vendors/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.0/vendors/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/vendors/sync", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/vapid/projects/1/tools", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.0/projects/1/tools", _) do
+    %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
+  end
+
+  def patch(_, "/rest/v1.1/projects/1/tools", _) do
     %ResponseResult{status_code: 200, parsed_body: %{}, reply: :ok}
   end
 end

--- a/test/resources/bid_packages_test.exs
+++ b/test/resources/bid_packages_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.BidPackagesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.BidPackages
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.BidPackagesTest do
              BidPackages.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             BidPackages.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             BidPackages.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "bid_package" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             BidPackages.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "bid_package" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             BidPackages.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "bid_package" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              BidPackages.create(client, params)

--- a/test/resources/calendar_events_test.exs
+++ b/test/resources/calendar_events_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.CalendarEventsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CalendarEvents
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CalendarEvents.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CalendarEvents.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              CalendarEvents.list(client, params)

--- a/test/resources/change_event_statuses_test.exs
+++ b/test/resources/change_event_statuses_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.ChangeEventStatusesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ChangeEventStatuses
 
-  test "list/1" do
+  test "list/1 with default API version " do
     client = Procore.client()
     params = %{"company_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeEventStatuses.list(client, params)
+  end
+
+  test "list/1 with specified rest API version " do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeEventStatuses.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version " do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              ChangeEventStatuses.list(client, params)

--- a/test/resources/change_events_test.exs
+++ b/test/resources/change_events_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ChangeEventsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ChangeEvents
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,53 @@ defmodule Procore.Resources.ChangeEventsTest do
              ChangeEvents.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeEvents.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeEvents.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "attachments" => [], "change_event" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ChangeEvents.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "attachments" => [],
+      "change_event" => %{},
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ChangeEvents.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "attachments" => [],
+      "change_event" => %{},
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ChangeEvents.create(client, params)

--- a/test/resources/change_order_statuses_test.exs
+++ b/test/resources/change_order_statuses_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.ChangeOrderStatusesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ChangeOrderStatuses
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeOrderStatuses.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ChangeOrderStatuses.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              ChangeOrderStatuses.list(client, params)

--- a/test/resources/commitment_line_item_types_test.exs
+++ b/test/resources/commitment_line_item_types_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.CommitmentLineItemTypesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CommitmentLineItemTypes
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.CommitmentLineItemTypesTest do
              CommitmentLineItemTypes.list(client, params)
   end
 
-  test "sync/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CommitmentLineItemTypes.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CommitmentLineItemTypes.list(client, params)
+  end
+
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "line_item_types" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CommitmentLineItemTypes.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "line_item_types" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CommitmentLineItemTypes.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "line_item_types" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              CommitmentLineItemTypes.sync(client, params)

--- a/test/resources/companies_test.exs
+++ b/test/resources/companies_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.CompaniesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Companies
 
-  test "find/1" do
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"id" => 1}
 
@@ -11,9 +11,43 @@ defmodule Procore.Resources.CompaniesTest do
              Companies.find(client, params)
   end
 
-  test "list/1" do
+  test "find/1 with specified rest API version" do
     client = Procore.client()
+    params = %{"id" => 1, "api_version" => "v1.1"}
 
-    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} = Companies.list(client)
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Companies.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Companies.find(client, params)
+  end
+
+  test "list/1 with default API version" do
+    client = Procore.client()
+    params = %{}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Companies.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Companies.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Companies.list(client, params)
   end
 end

--- a/test/resources/company_checklist_template_sections_test.exs
+++ b/test/resources/company_checklist_template_sections_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.CompanyChecklistTemplateSectionsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CompanyChecklistTemplateSections
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "list_template_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.CompanyChecklistTemplateSectionsTest do
              CompanyChecklistTemplateSections.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "list_template_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyChecklistTemplateSections.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "list_template_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyChecklistTemplateSections.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "section_id" => 1}
 
@@ -19,9 +35,53 @@ defmodule Procore.Resources.CompanyChecklistTemplateSectionsTest do
              CompanyChecklistTemplateSections.find(client, params)
   end
 
-  test "bulk_create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "section_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CompanyChecklistTemplateSections.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "section_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CompanyChecklistTemplateSections.find(client, params)
+  end
+
+  test "bulk_create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "list_template_id" => 1, "sections" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: []} =
+             CompanyChecklistTemplateSections.bulk_create(client, params)
+  end
+
+  test "bulk_create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "company_id" => 1,
+      "list_template_id" => 1,
+      "sections" => [],
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: []} =
+             CompanyChecklistTemplateSections.bulk_create(client, params)
+  end
+
+  test "bulk_create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "company_id" => 1,
+      "list_template_id" => 1,
+      "sections" => [],
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: []} =
              CompanyChecklistTemplateSections.bulk_create(client, params)

--- a/test/resources/company_checklist_templates_test.exs
+++ b/test/resources/company_checklist_templates_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.CompanyChecklistTemplatesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CompanyChecklistTemplates
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.CompanyChecklistTemplatesTest do
              CompanyChecklistTemplates.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyChecklistTemplates.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyChecklistTemplates.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "list_template_id" => 1}
 
@@ -19,9 +35,53 @@ defmodule Procore.Resources.CompanyChecklistTemplatesTest do
              CompanyChecklistTemplates.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "list_template_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CompanyChecklistTemplates.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "list_template_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             CompanyChecklistTemplates.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "list_template" => %{}, "attachments" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             CompanyChecklistTemplates.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "company_id" => 1,
+      "list_template" => %{},
+      "attachments" => [],
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             CompanyChecklistTemplates.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "company_id" => 1,
+      "list_template" => %{},
+      "attachments" => [],
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              CompanyChecklistTemplates.create(client, params)

--- a/test/resources/company_observation_templates_test.exs
+++ b/test/resources/company_observation_templates_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.CompanyObservationTemplatesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CompanyObservationTemplates
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.CompanyObservationTemplatesTest do
              CompanyObservationTemplates.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyObservationTemplates.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CompanyObservationTemplates.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "observation_template" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             CompanyObservationTemplates.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "observation_template" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             CompanyObservationTemplates.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "observation_template" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              CompanyObservationTemplates.create(client, params)

--- a/test/resources/contributing_behaviors_test.exs
+++ b/test/resources/contributing_behaviors_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ContributingBehaviorsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ContributingBehaviors
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ContributingBehaviorsTest do
              ContributingBehaviors.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ContributingBehaviors.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ContributingBehaviors.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"contributing_behavior_id" => 1, "company_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ContributingBehaviorsTest do
              ContributingBehaviors.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"contributing_behavior_id" => 1, "company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ContributingBehaviors.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"contributing_behavior_id" => 1, "company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ContributingBehaviors.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "contributing_behavior" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ContributingBehaviors.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "contributing_behavior" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ContributingBehaviors.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "contributing_behavior" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ContributingBehaviors.create(client, params)

--- a/test/resources/contributing_conditions_test.exs
+++ b/test/resources/contributing_conditions_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ContributingConditionsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ContributingConditions
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ContributingConditionsTest do
              ContributingConditions.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ContributingConditions.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ContributingConditions.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"contributing_condition_id" => 1, "company_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ContributingConditionsTest do
              ContributingConditions.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"contributing_condition_id" => 1, "company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ContributingConditions.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"contributing_condition_id" => 1, "company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ContributingConditions.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "contributing_condition" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ContributingConditions.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "contributing_condition" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ContributingConditions.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "contributing_condition" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ContributingConditions.create(client, params)

--- a/test/resources/cost_codes_test.exs
+++ b/test/resources/cost_codes_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.CostCodesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.CostCodes
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CostCodes.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             CostCodes.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              CostCodes.list(client, params)

--- a/test/resources/drawing_areas_test.exs
+++ b/test/resources/drawing_areas_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.DrawingAreasTest do
   alias Procore.ResponseResult
   alias Procore.Resources.DrawingAreas
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.DrawingAreasTest do
              DrawingAreas.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             DrawingAreas.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             DrawingAreas.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "name" => "Area A"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             DrawingAreas.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "name" => "Area A", "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             DrawingAreas.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "name" => "Area A", "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              DrawingAreas.create(client, params)

--- a/test/resources/hazards_test.exs
+++ b/test/resources/hazards_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.HazardsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Hazards
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.HazardsTest do
              Hazards.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Hazards.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Hazards.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"hazard_id" => 1, "company_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.HazardsTest do
              Hazards.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"hazard_id" => 1, "company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Hazards.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"hazard_id" => 1, "company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Hazards.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "hazard" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Hazards.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "hazard" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Hazards.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "hazard" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Hazards.create(client, params)

--- a/test/resources/image_categories_test.exs
+++ b/test/resources/image_categories_test.exs
@@ -1,14 +1,14 @@
-defmodule Procore.Resources.ImagesTest do
+defmodule Procore.Resources.ImageCategoriesTest do
   use ExUnit.Case
   alias Procore.ResponseResult
-  alias Procore.Resources.Images
+  alias Procore.Resources.ImageCategories
 
   test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Images.list(client, params)
+             ImageCategories.list(client, params)
   end
 
   test "list/1 with specified rest API version" do
@@ -16,7 +16,7 @@ defmodule Procore.Resources.ImagesTest do
     params = %{"project_id" => 1, "api_version" => "v1.1"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Images.list(client, params)
+             ImageCategories.list(client, params)
   end
 
   test "list/1 with specified vapid API version" do
@@ -24,50 +24,32 @@ defmodule Procore.Resources.ImagesTest do
     params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Images.list(client, params)
+             ImageCategories.list(client, params)
   end
 
   test "create/1 with default API version" do
     client = Procore.client()
+    params = %{"project_id" => 1, "image_category" => %{}}
 
-    params = %{
-      "project_id" => 1,
-      "image_category_id" => 1,
-      "filename" => "filename.jpg",
-      "path_to_file" => "/path/to/file/filename.jpg"
-    }
+    ImageCategories.create(client, params)
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Images.create(client, params)
+             ImageCategories.create(client, params)
   end
 
   test "create/1 with specified rest API version" do
     client = Procore.client()
-
-    params = %{
-      "project_id" => 1,
-      "image_category_id" => 1,
-      "filename" => "filename.jpg",
-      "path_to_file" => "/path/to/file/filename.jpg",
-      "api_version" => "v1.1"
-    }
+    params = %{"project_id" => 1, "image_category" => %{}, "api_version" => "v1.1"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Images.create(client, params)
+             ImageCategories.create(client, params)
   end
 
   test "create/1 with specified vapid API version" do
     client = Procore.client()
-
-    params = %{
-      "project_id" => 1,
-      "image_category_id" => 1,
-      "filename" => "filename.jpg",
-      "path_to_file" => "/path/to/file/filename.jpg",
-      "api_version" => "vapid"
-    }
+    params = %{"project_id" => 1, "image_category" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Images.create(client, params)
+             ImageCategories.create(client, params)
   end
 end

--- a/test/resources/inspection_types_test.exs
+++ b/test/resources/inspection_types_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.InspectionTypesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.InspectionTypes
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.InspectionTypesTest do
              InspectionTypes.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             InspectionTypes.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             InspectionTypes.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "inspection_type" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             InspectionTypes.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "inspection_type" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             InspectionTypes.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "inspection_type" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              InspectionTypes.create(client, params)

--- a/test/resources/locations_test.exs
+++ b/test/resources/locations_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.LocationsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Locations
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.LocationsTest do
              Locations.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Locations.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Locations.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "location" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Locations.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "location" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Locations.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "location" => %{}, "api_version" => "v1.1"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Locations.create(client, params)

--- a/test/resources/meeting_categories_test.exs
+++ b/test/resources/meeting_categories_test.exs
@@ -3,9 +3,37 @@ defmodule Procore.Resources.MeetingsCategoriesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.MeetingCategories
 
-  test "create/1" do
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"meeting_id" => 1, "project_id" => 1, "meeting_category" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             MeetingCategories.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "meeting_id" => 1,
+      "project_id" => 1,
+      "meeting_category" => %{},
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             MeetingCategories.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "meeting_id" => 1,
+      "project_id" => 1,
+      "meeting_category" => %{},
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              MeetingCategories.create(client, params)

--- a/test/resources/observation_item_response_logs_test.exs
+++ b/test/resources/observation_item_response_logs_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ObservationItemResponseLogsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ObservationItemResponseLogs
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "observation_item_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ObservationItemResponseLogsTest do
              ObservationItemResponseLogs.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "observation_item_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationItemResponseLogs.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "observation_item_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationItemResponseLogs.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
 
     params = %{
@@ -20,6 +36,38 @@ defmodule Procore.Resources.ObservationItemResponseLogsTest do
       "status" => "initiated",
       "attachments" => [],
       "observation_item_id" => 1
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ObservationItemResponseLogs.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "reponse_log" => %{},
+      "status" => "initiated",
+      "attachments" => [],
+      "observation_item_id" => 1,
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ObservationItemResponseLogs.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "reponse_log" => %{},
+      "status" => "initiated",
+      "attachments" => [],
+      "observation_item_id" => 1,
+      "api_version" => "vapid"
     }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =

--- a/test/resources/observation_items_test.exs
+++ b/test/resources/observation_items_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ObservationItemsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ObservationItems
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ObservationItemsTest do
              ObservationItems.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationItems.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationItems.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"observation_item_id" => 1, "project_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ObservationItemsTest do
              ObservationItems.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"observation_item_id" => 1, "project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ObservationItems.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"observation_item_id" => 1, "project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ObservationItems.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "observation" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ObservationItems.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "observation" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ObservationItems.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "observation" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ObservationItems.create(client, params)

--- a/test/resources/observation_types_test.exs
+++ b/test/resources/observation_types_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.ObservationTypesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ObservationTypes
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationTypes.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ObservationTypes.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              ObservationTypes.list(client, params)

--- a/test/resources/offices_test.exs
+++ b/test/resources/offices_test.exs
@@ -5,9 +5,25 @@ defmodule Procore.Resources.OfficesTest do
 
   doctest Procore.Resources.Offices
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Offices.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Offices.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              Offices.list(client, params)

--- a/test/resources/permission_templates_test.exs
+++ b/test/resources/permission_templates_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.PermissionTemplatesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.PermissionTemplates
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PermissionTemplates.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PermissionTemplates.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              PermissionTemplates.list(client, params)

--- a/test/resources/prime_contracts_test.exs
+++ b/test/resources/prime_contracts_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.PrimeContractsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.PrimeContracts
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.PrimeContractsTest do
              PrimeContracts.list(client, params)
   end
 
-  test "find/2" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PrimeContracts.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PrimeContracts.list(client, params)
+  end
+
+  test "find/2 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "prime_contract_id" => 1}
 
@@ -19,9 +35,53 @@ defmodule Procore.Resources.PrimeContractsTest do
              PrimeContracts.find(client, params)
   end
 
-  test "create/1" do
+  test "find/2 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "prime_contract_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PrimeContracts.find(client, params)
+  end
+
+  test "find/2 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "prime_contract_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PrimeContracts.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "attachments" => [], "prime_contract" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PrimeContracts.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "attachments" => [],
+      "prime_contract" => %{},
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PrimeContracts.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "attachments" => [],
+      "prime_contract" => %{},
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              PrimeContracts.create(client, params)

--- a/test/resources/project_checklist_templates_test.exs
+++ b/test/resources/project_checklist_templates_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ProjectChecklistTemplatesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ProjectChecklistTemplates
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ProjectChecklistTemplatesTest do
              ProjectChecklistTemplates.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectChecklistTemplates.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectChecklistTemplates.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "list_template_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ProjectChecklistTemplatesTest do
              ProjectChecklistTemplates.find(client, params)
   end
 
-  test "create_from_company_template/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "list_template_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectChecklistTemplates.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "list_template_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectChecklistTemplates.find(client, params)
+  end
+
+  test "create_from_company_template/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "source_template_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ProjectChecklistTemplates.create_from_company_template(client, params)
+  end
+
+  test "create_from_company_template/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "source_template_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ProjectChecklistTemplates.create_from_company_template(client, params)
+  end
+
+  test "create_from_company_template/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "source_template_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ProjectChecklistTemplates.create_from_company_template(client, params)

--- a/test/resources/project_checklists_test.exs
+++ b/test/resources/project_checklists_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ProjectChecklistsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ProjectChecklists
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ProjectChecklistsTest do
              ProjectChecklists.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectChecklists.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectChecklists.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "checklist_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ProjectChecklistsTest do
              ProjectChecklists.find(client, params)
   end
 
-  test "create/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "checklist_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectChecklists.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "checklist_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectChecklists.find(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "template_id" => 1, "list" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ProjectChecklists.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "template_id" => 1, "list" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ProjectChecklists.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "template_id" => 1, "list" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ProjectChecklists.create(client, params)

--- a/test/resources/project_configurations_test.exs
+++ b/test/resources/project_configurations_test.exs
@@ -5,9 +5,25 @@ defmodule Procore.Resources.ProjectConfigurationsTest do
 
   doctest Procore.Resources.ProjectConfigurations
 
-  test "get/1" do
+  test "get/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 2}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectConfigurations.find(client, params)
+  end
+
+  test "get/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 2, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectConfigurations.find(client, params)
+  end
+
+  test "get/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 2, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              ProjectConfigurations.find(client, params)

--- a/test/resources/project_tools_test.exs
+++ b/test/resources/project_tools_test.exs
@@ -1,0 +1,59 @@
+defmodule Procore.Resources.ProjectToolsTest do
+  use ExUnit.Case
+  alias Procore.ResponseResult
+  alias Procore.Resources.ProjectTools
+
+  test "list/1 with default API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectTools.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectTools.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ProjectTools.list(client, params)
+  end
+
+  test "update/1 with default API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "project_tools" => []}
+
+    ProjectTools.update(client, params)
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectTools.update(client, params)
+  end
+
+  test "update/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "project_tools" => [], "api_version" => "v1.1"}
+
+    ProjectTools.update(client, params)
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectTools.update(client, params)
+  end
+
+  test "update/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "project_tools" => [], "api_version" => "vapid"}
+
+    ProjectTools.update(client, params)
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ProjectTools.update(client, params)
+  end
+end

--- a/test/resources/projects_test.exs
+++ b/test/resources/projects_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ProjectsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Projects
 
-  test "find/1" do
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.ProjectsTest do
              Projects.find(client, params)
   end
 
-  test "list/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Projects.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Projects.find(client, params)
+  end
+
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.ProjectsTest do
              Projects.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Projects.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Projects.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "project" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Projects.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "project" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Projects.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "project" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Projects.create(client, params)

--- a/test/resources/punch_items_test.exs
+++ b/test/resources/punch_items_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.PunchItemsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.PunchItems
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.PunchItemsTest do
              PunchItems.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PunchItems.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PunchItems.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "punch_item" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PunchItems.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "punch_item" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PunchItems.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "punch_item" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              PunchItems.create(client, params)

--- a/test/resources/purchase_order_contract_line_items_test.exs
+++ b/test/resources/purchase_order_contract_line_items_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.PurchaseOrderContractLineItemsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.PurchaseOrderContractLineItems
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "purchase_order_contract_id" => 1}
 
@@ -11,9 +11,53 @@ defmodule Procore.Resources.PurchaseOrderContractLineItemsTest do
              PurchaseOrderContractLineItems.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contract_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PurchaseOrderContractLineItems.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contract_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PurchaseOrderContractLineItems.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "purchase_order_contract_id" => 1, "line_item" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PurchaseOrderContractLineItems.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "purchase_order_contract_id" => 1,
+      "line_item" => %{},
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             PurchaseOrderContractLineItems.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "purchase_order_contract_id" => 1,
+      "line_item" => %{},
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              PurchaseOrderContractLineItems.create(client, params)

--- a/test/resources/purchase_order_contracts_test.exs
+++ b/test/resources/purchase_order_contracts_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.PurchaseOrderContractsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.PurchaseOrderContracts
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.PurchaseOrderContractsTest do
              PurchaseOrderContracts.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PurchaseOrderContracts.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             PurchaseOrderContracts.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "purchase_order_contract_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.PurchaseOrderContractsTest do
              PurchaseOrderContracts.find(client, params)
   end
 
-  test "sync/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contract_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PurchaseOrderContracts.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contract_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PurchaseOrderContracts.find(client, params)
+  end
+
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "purchase_order_contracts" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PurchaseOrderContracts.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contracts" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             PurchaseOrderContracts.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "purchase_order_contracts" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              PurchaseOrderContracts.sync(client, params)

--- a/test/resources/rfis/replies_test.exs
+++ b/test/resources/rfis/replies_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.Rfis.RepliesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Rfis.Replies
 
-  test "create/1" do
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "rfi_id" => 1, "reply" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Replies.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "rfi_id" => 1, "reply" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Replies.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "rfi_id" => 1, "reply" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Replies.create(client, params)

--- a/test/resources/rfis_test.exs
+++ b/test/resources/rfis_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.RfisTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Rfis
 
-  test "find/1" do
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"id" => 1, "project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.RfisTest do
              Rfis.find(client, params)
   end
 
-  test "list/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"id" => 1, "project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Rfis.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"id" => 1, "project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Rfis.find(client, params)
+  end
+
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.RfisTest do
              Rfis.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Rfis.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Rfis.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "rfi" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Rfis.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "rfi" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Rfis.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "rfi" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Rfis.create(client, params)

--- a/test/resources/schedule_resources_test.exs
+++ b/test/resources/schedule_resources_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.ScheduleResourcesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ScheduleResources
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.ScheduleResourcesTest do
              ScheduleResources.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ScheduleResources.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             ScheduleResources.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "resource" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ScheduleResources.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "resource" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ScheduleResources.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "resource" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ScheduleResources.create(client, params)

--- a/test/resources/schedule_tasks_test.exs
+++ b/test/resources/schedule_tasks_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.ScheduleTasksTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ScheduleTasks
 
-  test "create/1" do
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "task" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ScheduleTasks.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "task" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             ScheduleTasks.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "task" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              ScheduleTasks.create(client, params)

--- a/test/resources/schedule_todos_test.exs
+++ b/test/resources/schedule_todos_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.ScheduleTodosTest do
   alias Procore.ResponseResult
   alias Procore.Resources.ScheduleTodos
 
-  test "sync/1" do
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "todos" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ScheduleTodos.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "todos" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             ScheduleTodos.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "todos" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              ScheduleTodos.sync(client, params)

--- a/test/resources/specification_sets_test.exs
+++ b/test/resources/specification_sets_test.exs
@@ -1,30 +1,30 @@
-defmodule Procore.Resources.MeetingsTest do
+defmodule Procore.Resources.SpecificationSetsTemplatesTest do
   use ExUnit.Case
   alias Procore.ResponseResult
-  alias Procore.Resources.Meetings
+  alias Procore.Resources.SpecificationSets
 
   test "find/1 with default API version" do
     client = Procore.client()
-    params = %{"meeting_id" => 1, "project_id" => 1}
+    params = %{"project_id" => 1, "id" => 2}
 
-    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
-             Meetings.find(client, params)
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SpecificationSets.find(client, params)
   end
 
   test "find/1 with specified rest API version" do
     client = Procore.client()
-    params = %{"meeting_id" => 1, "project_id" => 1, "api_version" => "v1.1"}
+    params = %{"project_id" => 1, "id" => 2, "api_version" => "v1.1"}
 
-    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
-             Meetings.find(client, params)
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SpecificationSets.find(client, params)
   end
 
   test "find/1 with specified vapid API version" do
     client = Procore.client()
-    params = %{"meeting_id" => 1, "project_id" => 1, "api_version" => "vapid"}
+    params = %{"project_id" => 1, "id" => 2, "api_version" => "vapid"}
 
-    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
-             Meetings.find(client, params)
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SpecificationSets.find(client, params)
   end
 
   test "list/1 with default API version" do
@@ -32,7 +32,7 @@ defmodule Procore.Resources.MeetingsTest do
     params = %{"project_id" => 1}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Meetings.list(client, params)
+             SpecificationSets.list(client, params)
   end
 
   test "list/1 with specified rest API version" do
@@ -40,7 +40,7 @@ defmodule Procore.Resources.MeetingsTest do
     params = %{"project_id" => 1, "api_version" => "v1.1"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Meetings.list(client, params)
+             SpecificationSets.list(client, params)
   end
 
   test "list/1 with specified vapid API version" do
@@ -48,30 +48,30 @@ defmodule Procore.Resources.MeetingsTest do
     params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
-             Meetings.list(client, params)
+             SpecificationSets.list(client, params)
   end
 
   test "create/1 with default API version" do
     client = Procore.client()
-    params = %{"project_id" => 1, "meeting" => %{}}
+    params = %{"project_id" => 1, "specification_set" => %{}}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Meetings.create(client, params)
+             SpecificationSets.create(client, params)
   end
 
   test "create/1 with specified rest API version" do
     client = Procore.client()
-    params = %{"project_id" => 1, "meeting" => %{}, "api_version" => "v1.1"}
+    params = %{"project_id" => 1, "specification_set" => %{}, "api_version" => "v1.1"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Meetings.create(client, params)
+             SpecificationSets.create(client, params)
   end
 
   test "create/1 with specified vapid API version" do
     client = Procore.client()
-    params = %{"project_id" => 1, "meeting" => %{}, "api_version" => "vapid"}
+    params = %{"project_id" => 1, "specification_set" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             Meetings.create(client, params)
+             SpecificationSets.create(client, params)
   end
 end

--- a/test/resources/specification_uploads_test.exs
+++ b/test/resources/specification_uploads_test.exs
@@ -1,41 +1,43 @@
-defmodule Procore.Resources.MeetingsTopicsTest do
+defmodule Procore.SpecificationUploadsTest do
   use ExUnit.Case
   alias Procore.ResponseResult
-  alias Procore.Resources.MeetingTopics
+  alias Procore.Resources.SpecificationUploads
 
   test "create/1 with default API version" do
     client = Procore.client()
-    params = %{"meeting_id" => 1, "project_id" => 1, "meeting_topic" => %{}}
+
+    params = %{
+      "project_id" => 1,
+      "specification_upload" => %{:specification_set_id => "1", :files => []}
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             MeetingTopics.create(client, params)
+             SpecificationUploads.create(client, params)
   end
 
   test "create/1 with specified rest API version" do
     client = Procore.client()
 
     params = %{
-      "meeting_id" => 1,
       "project_id" => 1,
-      "meeting_topic" => %{},
+      "specification_upload" => %{:specification_set_id => "1", :files => []},
       "api_version" => "v1.1"
     }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             MeetingTopics.create(client, params)
+             SpecificationUploads.create(client, params)
   end
 
   test "create/1 with specified vapid API version" do
     client = Procore.client()
 
     params = %{
-      "meeting_id" => 1,
       "project_id" => 1,
-      "meeting_topic" => %{},
+      "specification_upload" => %{:specification_set_id => "1", :files => []},
       "api_version" => "vapid"
     }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
-             MeetingTopics.create(client, params)
+             SpecificationUploads.create(client, params)
   end
 end

--- a/test/resources/submittal_packages_test.exs
+++ b/test/resources/submittal_packages_test.exs
@@ -3,9 +3,25 @@ defmodule Procore.Resources.SubmittalPackagessTest do
   alias Procore.ResponseResult
   alias Procore.Resources.SubmittalPackages
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SubmittalPackages.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SubmittalPackages.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              SubmittalPackages.list(client, params)

--- a/test/resources/submittal_status_test.exs
+++ b/test/resources/submittal_status_test.exs
@@ -4,9 +4,25 @@ defmodule Procore.Resources.SubmittalStatusTest do
   alias Procore.ResponseResult
   alias Procore.Resources.SubmittalStatus
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SubmittalStatus.list(client, params)
+  end
+
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             SubmittalStatus.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
              SubmittalStatus.list(client, params)

--- a/test/resources/submittals_test.exs
+++ b/test/resources/submittals_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.SubmittalsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Submittals
 
-  test "find/1" do
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"id" => 1, "project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.SubmittalsTest do
              Submittals.find(client, params)
   end
 
-  test "list/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"id" => 1, "project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"id" => 1, "project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.find(client, params)
+  end
+
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -19,7 +35,23 @@ defmodule Procore.Resources.SubmittalsTest do
              Submittals.list(client, params)
   end
 
-  test "list_potential_responsible_contractors/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.list(client, params)
+  end
+
+  test "list_potential_responsible_contractors/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -27,9 +59,41 @@ defmodule Procore.Resources.SubmittalsTest do
              Submittals.list_potential_responsible_contractors(client, params)
   end
 
-  test "create/1" do
+  test "list_potential_responsible_contractors/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.list_potential_responsible_contractors(client, params)
+  end
+
+  test "list_potential_responsible_contractors/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Submittals.list_potential_responsible_contractors(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "submittal" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Submittals.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "submittal" => %{}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Submittals.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "submittal" => %{}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Submittals.create(client, params)

--- a/test/resources/trades_test.exs
+++ b/test/resources/trades_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.TradesTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Trades
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,9 +11,41 @@ defmodule Procore.Resources.TradesTest do
              Trades.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Trades.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Trades.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "trade" => %{"name" => "Trade A"}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Trades.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "trade" => %{"name" => "Trade A"}, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             Trades.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "trade" => %{"name" => "Trade A"}, "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              Trades.create(client, params)

--- a/test/resources/users_test.exs
+++ b/test/resources/users_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.UsersTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Users
 
-  test "add_user_to_project/1" do
+  test "add_user_to_project/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "user_id" => 1, "permission_template_id" => 1}
 
@@ -11,7 +11,35 @@ defmodule Procore.Resources.UsersTest do
              Users.add_user_to_project(client, params)
   end
 
-  test "list/1 for company directory" do
+  test "add_user_to_project/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "user_id" => 1,
+      "permission_template_id" => 1,
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Users.add_user_to_project(client, params)
+  end
+
+  test "add_user_to_project/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "user_id" => 1,
+      "permission_template_id" => 1,
+      "api_version" => "vapid"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Users.add_user_to_project(client, params)
+  end
+
+  test "list/1 for company directory with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -19,7 +47,23 @@ defmodule Procore.Resources.UsersTest do
              Users.list(client, params)
   end
 
-  test "list/1 for project directory" do
+  test "list/1 for company directory with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Users.list(client, params)
+  end
+
+  test "list/1 for company directory with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Users.list(client, params)
+  end
+
+  test "list/1 for project directory with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -27,9 +71,41 @@ defmodule Procore.Resources.UsersTest do
              Users.list(client, params)
   end
 
-  test "sync/1" do
+  test "list/1 for project directory with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Users.list(client, params)
+  end
+
+  test "list/1 for project directory with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Users.list(client, params)
+  end
+
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "users" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Users.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "users" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Users.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "users" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              Users.sync(client, params)

--- a/test/resources/vendors_test.exs
+++ b/test/resources/vendors_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.VendorsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.Vendors
 
-  test "list/1 for a company directory" do
+  test "list/1 for a company directory with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.VendorsTest do
              Vendors.list(client, params)
   end
 
-  test "list/1 for a project directory" do
+  test "list/1 for a company directory with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Vendors.list(client, params)
+  end
+
+  test "list/1 for a company directory with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Vendors.list(client, params)
+  end
+
+  test "list/1 for a project directory with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -19,7 +35,23 @@ defmodule Procore.Resources.VendorsTest do
              Vendors.list(client, params)
   end
 
-  test "add_vendor_to_project/1" do
+  test "list/1 for a project directory with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Vendors.list(client, params)
+  end
+
+  test "list/1 for a project directory with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             Vendors.list(client, params)
+  end
+
+  test "add_vendor_to_project/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "vendor_id" => 1}
 
@@ -27,9 +59,41 @@ defmodule Procore.Resources.VendorsTest do
              Vendors.add_vendor_to_project(client, params)
   end
 
-  test "sync/1" do
+  test "add_vendor_to_project/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "vendor_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Vendors.add_vendor_to_project(client, params)
+  end
+
+  test "add_vendor_to_project/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "vendor_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Vendors.add_vendor_to_project(client, params)
+  end
+
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"company_id" => 1, "vendors" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Vendors.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "vendors" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             Vendors.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"company_id" => 1, "vendors" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              Vendors.sync(client, params)

--- a/test/resources/work_order_contract_line_items_test.exs
+++ b/test/resources/work_order_contract_line_items_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.WorkOrderContractLineItemsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.WorkOrderContractLineItems
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "work_order_contract_id" => 1}
 
@@ -11,9 +11,53 @@ defmodule Procore.Resources.WorkOrderContractLineItemsTest do
              WorkOrderContractLineItems.list(client, params)
   end
 
-  test "create/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contract_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             WorkOrderContractLineItems.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contract_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             WorkOrderContractLineItems.list(client, params)
+  end
+
+  test "create/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "work_order_contract_id" => 1, "line_item" => %{}}
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             WorkOrderContractLineItems.create(client, params)
+  end
+
+  test "create/1 with specified rest API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "work_order_contract_id" => 1,
+      "line_item" => %{},
+      "api_version" => "v1.1"
+    }
+
+    assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
+             WorkOrderContractLineItems.create(client, params)
+  end
+
+  test "create/1 with specified vapid API version" do
+    client = Procore.client()
+
+    params = %{
+      "project_id" => 1,
+      "work_order_contract_id" => 1,
+      "line_item" => %{},
+      "api_version" => "vapid"
+    }
 
     assert %ResponseResult{reply: :ok, status_code: 201, parsed_body: %{}} =
              WorkOrderContractLineItems.create(client, params)

--- a/test/resources/work_order_contracts_test.exs
+++ b/test/resources/work_order_contracts_test.exs
@@ -3,7 +3,7 @@ defmodule Procore.Resources.WorkOrderContractsTest do
   alias Procore.ResponseResult
   alias Procore.Resources.WorkOrderContracts
 
-  test "list/1" do
+  test "list/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1}
 
@@ -11,7 +11,23 @@ defmodule Procore.Resources.WorkOrderContractsTest do
              WorkOrderContracts.list(client, params)
   end
 
-  test "find/1" do
+  test "list/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             WorkOrderContracts.list(client, params)
+  end
+
+  test "list/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: []} =
+             WorkOrderContracts.list(client, params)
+  end
+
+  test "find/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "work_order_contract_id" => 1}
 
@@ -19,9 +35,41 @@ defmodule Procore.Resources.WorkOrderContractsTest do
              WorkOrderContracts.find(client, params)
   end
 
-  test "sync/1" do
+  test "find/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contract_id" => 1, "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             WorkOrderContracts.find(client, params)
+  end
+
+  test "find/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contract_id" => 1, "api_version" => "vapid"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             WorkOrderContracts.find(client, params)
+  end
+
+  test "sync/1 with default API version" do
     client = Procore.client()
     params = %{"project_id" => 1, "work_order_contracts" => []}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             WorkOrderContracts.sync(client, params)
+  end
+
+  test "sync/1 with specified rest API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contracts" => [], "api_version" => "v1.1"}
+
+    assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
+             WorkOrderContracts.sync(client, params)
+  end
+
+  test "sync/1 with specified vapid API version" do
+    client = Procore.client()
+    params = %{"project_id" => 1, "work_order_contracts" => [], "api_version" => "vapid"}
 
     assert %ResponseResult{reply: :ok, status_code: 200, parsed_body: %{}} =
              WorkOrderContracts.sync(client, params)


### PR DESCRIPTION
## Ticket: [ZL-801 Update Elixir SDK to support Rest Versioning](https://procoretech.atlassian.net/browse/ZL-801)

## Description
Updates all resource endpoints to accept an optional `api_version` option which is used to determine the path for the resource.

e.g. 
```ex
Offices.list(%{"company_id" => 1, "api_version" => "v1.1"})
```
or
```ex
 Offices.list(%{"company_id" => 1, "api_version" => "vapid"})
```

Default version used when not including an `api_version` is `/rest/v1.0`