### PR TITLE
Send sdk version header

### DIFF
--- a/lib/procore/client_builder.ex
+++ b/lib/procore/client_builder.ex
@@ -46,8 +46,9 @@ defmodule Procore.ClientBuilder do
     vsn = Application.spec(:procore, :vsn) |> to_string()
 
     [
-      # Ex: "Procore-Sdk-Version: elixir-v1.0.1"
-      {"Procore-Sdk-Version", "elixir-#{vsn}"}
+      # Ex: "Procore-Sdk-Version: v1.0.1", "Procore-Sdk-Language: elixir"
+      {"Procore-Sdk-Version", "#{vsn}"},
+      {"Procore-Sdk-Language", "elixir"}
     ]
   end
 

--- a/lib/procore/client_builder.ex
+++ b/lib/procore/client_builder.ex
@@ -44,6 +44,7 @@ defmodule Procore.ClientBuilder do
     # [{"Content-Type", "multipart/form-data"}] # works for multipart
     # seems to work for both
     vsn = Application.spec(:procore, :vsn) |> to_string()
+
     [
       # Ex: "Procore-Sdk-Version: elixir-v1.0.1"
       {"Procore-Sdk-Version", "elixir-#{vsn}"}

--- a/lib/procore/client_builder.ex
+++ b/lib/procore/client_builder.ex
@@ -3,6 +3,7 @@ defmodule Procore.ClientBuilder do
 
   alias Tesla.Middleware.AuthorizationOAuth
   alias Tesla.Middleware.ClientCredentialsOAuth
+  alias Application
 
   def build(ClientCredentialsOAuth, client_id: client_id, client_secret: client_secret) do
     Tesla.build_client([
@@ -42,7 +43,11 @@ defmodule Procore.ClientBuilder do
     # [{"Content-Type", "application/json"}] # works for everything, besides multipart
     # [{"Content-Type", "multipart/form-data"}] # works for multipart
     # seems to work for both
-    []
+    vsn = Application.spec(:procore, :vsn) |> to_string()
+    [
+      # Ex: "Procore-Sdk-Version: elixir-v1.0.1"
+      {"Procore-Sdk-Version", "elixir-#{vsn}"}
+    ]
   end
 
   defp credentials_from_config(key) do

--- a/lib/tesla/middleware/authorization_oauth.ex
+++ b/lib/tesla/middleware/authorization_oauth.ex
@@ -12,6 +12,7 @@ defmodule Tesla.Middleware.AuthorizationOAuth do
   end
 
   def headers do
-    [{"Content-type", "application/json"}, {"Accept", "application/json"}]
+    {:ok, vsn} = :application.get_key(:my_app, :vsn)
+    [{"Content-type", "application/json"}, {"Accept", "application/json"}, {"Procore-Sdk-Version", List.to_string(vsn)}]
   end
 end

--- a/lib/tesla/middleware/authorization_oauth.ex
+++ b/lib/tesla/middleware/authorization_oauth.ex
@@ -14,7 +14,7 @@ defmodule Tesla.Middleware.AuthorizationOAuth do
   def headers do
     [
       {"Content-type", "application/json"},
-      {"Accept", "application/json"},
+      {"Accept", "application/json"}
     ]
   end
 end

--- a/lib/tesla/middleware/authorization_oauth.ex
+++ b/lib/tesla/middleware/authorization_oauth.ex
@@ -12,12 +12,9 @@ defmodule Tesla.Middleware.AuthorizationOAuth do
   end
 
   def headers do
-    {:ok, vsn} = :application.get_key(:my_app, :vsn)
-
     [
       {"Content-type", "application/json"},
       {"Accept", "application/json"},
-      {"Procore-Sdk-Version", List.to_string(vsn)}
     ]
   end
 end

--- a/lib/tesla/middleware/authorization_oauth.ex
+++ b/lib/tesla/middleware/authorization_oauth.ex
@@ -13,6 +13,11 @@ defmodule Tesla.Middleware.AuthorizationOAuth do
 
   def headers do
     {:ok, vsn} = :application.get_key(:my_app, :vsn)
-    [{"Content-type", "application/json"}, {"Accept", "application/json"}, {"Procore-Sdk-Version", List.to_string(vsn)}]
+
+    [
+      {"Content-type", "application/json"},
+      {"Accept", "application/json"},
+      {"Procore-Sdk-Version", List.to_string(vsn)}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Procore.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       start_permanent: Mix.env() == :prod,
-      version: "1.0.0"
+      version: "1.0.1"
     ]
   end
 


### PR DESCRIPTION
Send `Procore-Sdk-Version` in the headers to track usage.

```
iex(16)> client = Procore.client()
%Tesla.Client{
  fun: nil,
  post: [],
  pre: [
    {Tesla.Middleware.Headers, :call,
     [[{"Procore-Sdk-Version", "elixir-1.0.1"}]]},
    {Tesla.Middleware.BaseUrl, :call, ["https://api.procore.com"]},
    {Tesla.Middleware.ClientCredentialsOAuth, :call,
     [
       [
         client_id: "REDACTED",
         client_secret: "REDACTED",
         host: "https://api.procore.com"
       ]
     ]}
  ]
}

iex(3)> {:ok, response} = client |> Offices.list(%{"company_id" => 1})

12:58:52.016 [debug]
>>> REQUEST >>>
Query: company_id: 1

Authorization: Bearer eyJhbGciOiJFUzUxMiJ9.eyJhaWQiOiIyNmE5MmQ0ZTMzNzEwMzViZmFjMDE5NmVlZWRlOTY4MDM1MWZmYzZkY2U3ZjM2MmE4ZTliYWVjZTI2OWY3NjNjIiwiZXhwIjoxNjIyODQwMzMxLCJ1aWQiOm51bGwsInV1aWQiOm51bGx9.AH7y9Ko7m97vTlVaXqHMqp-tdtpsazeKSVQwngG889iNGauLdDKXHLaL3Xa5vkO-JsDx5Ezu4j-IooEXQ_PtKlsXAboDS2O1I-VfYTrp8aiRVxJk0FMHYMhSPHqe9wSjoQvCkqsDlU_8KGILbcMbpypTYA2Np-qsffwawttFpQDVhqku
Procore-Sdk-Version: elixir-1.0.1
``